### PR TITLE
Add Census GEOIDs and canonical names to download outputs

### DIFF
--- a/missouri_vsr/assets/processed.py
+++ b/missouri_vsr/assets/processed.py
@@ -658,8 +658,8 @@ def _add_canonical_names(
         return reports
     lookup: dict[str, str] = {}
     for _, row in agency_reference_geocoded.iterrows():
-        normalized = _first_non_empty(row, ["Normalized"])
-        canonical = _first_non_empty(row, ["Department", "Canonical"])
+        normalized = _first_non_empty(row, ["Normalized"]) or ""
+        canonical = _first_non_empty(row, ["Department", "Canonical"]) or ""
         if normalized and canonical:
             lookup[normalized] = canonical
     if not lookup:

--- a/tests/test_ops_functional.py
+++ b/tests/test_ops_functional.py
@@ -242,6 +242,17 @@ def test_add_canonical_names_empty_reference():
     assert "canonical_name" not in result.columns
 
 
+def test_add_canonical_names_na_values_in_reference():
+    # pd.NA in Department/Canonical/Normalized columns must not raise
+    reports = pd.DataFrame([{"agency": "Adair County Sheriff's Office", "year": 2023}])
+    ref = pd.DataFrame([
+        {"Normalized": "adair county sheriffs department", "Department": "Adair County Sheriff's Dept", "Canonical": pd.NA},
+        {"Normalized": pd.NA, "Department": pd.NA, "Canonical": pd.NA},
+    ])
+    result = _add_canonical_names(reports, ref)
+    assert result["canonical_name"].iloc[0] == "Adair County Sheriff's Dept"
+
+
 def test_build_agency_index_records_includes_census_geoid():
     pivoted = pd.DataFrame([{
         "agency": "Springfield Police Dept",


### PR DESCRIPTION
Closes #8.

## Summary

- `agency_index` download now includes `census_geoid` — a 7-digit place GEOID for municipal agencies or 5-digit county GEOID for county agencies, extracted from the stored Geocodio jurisdiction response. State and unclassified agencies get `null`.
- `vsr_statistics` download and `downloads_combined` now include a `canonical_name` column, joined from the agency reference crosswalk via normalized name matching.

## Test plan

- [x] All 15 tests in `tests/test_ops_functional.py` pass (13 new)
- [x] Rerun the `downloads` group in Dagster — `agency_reference_geocoded` must already be materialized
- [x] Spot-check `agency_index` output for a known municipal and county agency to confirm `census_geoid` is populated
- [x] Spot-check `vsr_statistics` output to confirm `canonical_name` column is present and non-null for known agencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)