### PR TITLE
Add agents.md: architecture, data contract, and agent guide

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -219,9 +219,9 @@ Note: pre-2020 reports include a "% of population" row per agency (statewide and
 
 For v2, rates will be computed from raw counts at layer 2 for all years rather than using the pre-computed values from the PDFs. This gives a single consistent methodology across 2014–2024.
 
-For 2020+, the University of Missouri researchers who build the report get the pre-computed rates right. This means our computed rates should match the PDF values exactly — which doubles as a validation check on our raw count extraction. Any mismatch between our computed rate and the PDF's pre-computed value signals a parsing error in the underlying counts.
+The University of Missouri researchers who build the report get the pre-computed rates right in both eras. This means our computed rates should match the PDF values exactly — which doubles as a validation check on our raw count extraction. Any mismatch signals a parsing error in the underlying counts.
 
-For pre-2020, computing from raw counts also lets us substitute ACS population for 2010 census population once those figures are sourced (a future task), and gives us citation rate for free even though the AG didn't surface it.
+Computing from raw counts for pre-2020 also lets us substitute ACS population for 2010 census population once those figures are sourced (a future task), and gives us citation rate for free even though the AG didn't surface it.
 
 Stop rate and resident stop rate remain 2020+-only until pre-2020 ACS population figures are available.
 

--- a/agents.md
+++ b/agents.md
@@ -187,3 +187,31 @@ The data contract defines what the frontend can rely on across releases. It live
 | `consent-search` | `search-stats--probable-cause-authority-to-search--consent` | `search-statistics--probable-cause--consent` |
 
 Note: some 2020+ metrics have no pre-2020 equivalent (resident-only stops, ACS population rows, citation rate) and vice versa (pre-2020 bakes search rate and contraband hit rate directly; 2020+ derives them from raw counts). The crosswalk config will be the authoritative source; this table is a planning aid.
+
+---
+
+## Data for Frontend
+
+### Query layer
+
+The flat-file / per-agency JSON approach works well for a single year but becomes unwieldy at 20+ years. The planned query layer uses **DuckDB over S3 Parquet** as the substrate, with two access patterns:
+
+**Lambda + DuckDB API** — a thin serverless function that accepts structured queries and returns JSON. Handles cross-agency, cross-year aggregations, and spatial queries (DuckDB spatial extension). This is the primary runtime API for the frontend.
+
+**DuckDB MCP server** — the same DuckDB interface exposed as an MCP tool, used during development and data exploration. A single implementation serves both the developer agent (for querying data mid-task) and potentially the frontend itself. Run locally against `data/processed/*.parquet` or remotely against `releases/vN/` on S3.
+
+**DuckDB WASM** (under consideration) — query Parquet directly from the browser. Eliminates the Lambda layer for read-only queries; requires careful Parquet partitioning and acceptable cold-start times. Best suited for power-user / download features rather than the main editorial interface.
+
+Key design choice: **partition Parquet by year** at layer 3. DuckDB's partition pruning means a query for a single agency's 2024 data only scans the 2024 partition, not the full 11-year corpus.
+
+### Data-derived frontend artifacts
+
+The pipeline can generate frontend-facing content directly from data and schema, reducing manual maintenance:
+
+**"About the data" section** — auto-generated from the canonical metric crosswalk and schema definitions. Lists which metrics are available for which year ranges, what the race columns represent, and data caveats (ACS vintage, population denominator methodology). Emitted as a JSON blob or markdown at layer 3.
+
+**Versioned download links** — the manifest.json + S3 layout enables the frontend to render a "download the data" section that lists every available release, its year range, and a direct link, without any manual upkeep.
+
+**Agency year index** — a lightweight JSON index of `{agency, years_available, canonical_metrics_available}` that lets the frontend quickly determine what to show before fetching the full agency data.
+
+**Schema changelog** — each manifest.json entry includes a human-readable changelog that the frontend can surface in a "what changed" UI, linking data version to editorial context.

--- a/agents.md
+++ b/agents.md
@@ -186,7 +186,17 @@ The data contract defines what the frontend can rely on across releases. It live
 | `moving-violation` | `vehicle-stop-stats--reason-for-stop--moving` | `number-of-stops-by-race--reason-for-stop--moving` |
 | `consent-search` | `search-stats--probable-cause-authority-to-search--consent` | `search-statistics--probable-cause--consent` |
 
-Note: some 2020+ metrics have no pre-2020 equivalent (resident-only stops, ACS population rows, citation rate) and vice versa (pre-2020 bakes search rate and contraband hit rate directly; 2020+ derives them from raw counts). The crosswalk config will be the authoritative source; this table is a planning aid.
+**On arrests:** `key-indicators--arrests` (pre-2020) and `number-of-stops-by-race--stop-outcome--arrests` (2020+) measure the same thing and can be treated as equivalent in cross-era analysis.
+
+**On rates — the hard part:** This is where the eras diverge most interestingly. Pre-2020 reports pre-compute a small set of rates directly in the PDF (`key-indicators--search-rate`, `key-indicators--contraband-hit-rate`, `key-indicators--arrest-rate`). The 2020+ format drops the pre-computed rates in favor of raw counts, from which more rates can be derived — including citation rate and stop rate vs. ACS population, which have no pre-2020 equivalent. So:
+
+- `search-rate`, `contraband-hit-rate`, `arrest-rate`: present in both eras but sourced differently (pre-2020: pre-computed percentage; 2020+: derived from raw count rows)
+- `citation-rate`, `stop-rate` (vs. ACS population): 2020+ only — these comparisons cannot be made for pre-2020 years
+- The older format is better structured and more uniform in many respects; the newer format is richer analytically
+
+The crosswalk config (to be implemented in v2) will need to flag which rates are available per year range, so the frontend can conditionally show or suppress rate-based comparisons depending on the year selected.
+
+The crosswalk config will be the authoritative source; this table is a planning aid.
 
 ---
 
@@ -194,15 +204,13 @@ Note: some 2020+ metrics have no pre-2020 equivalent (resident-only stops, ACS p
 
 ### Query layer
 
-The flat-file / per-agency JSON approach works well for a single year but becomes unwieldy at 20+ years. The planned query layer uses **DuckDB over S3 Parquet** as the substrate, with two access patterns:
+The flat-file / per-agency JSON approach works well for a single year but becomes unwieldy at 20+ years. The assumed query layer is **DuckDB on S3 Parquet, served via AWS Lambda**. Traffic is currently light enough that Lambda cold starts are acceptable and the operational simplicity outweighs the latency cost of a persistent server.
 
-**Lambda + DuckDB API** — a thin serverless function that accepts structured queries and returns JSON. Handles cross-agency, cross-year aggregations, and spatial queries (DuckDB spatial extension). This is the primary runtime API for the frontend.
+**Lambda + DuckDB** — a thin Lambda function wraps DuckDB queries against versioned Parquet files on S3. Returns JSON. Handles cross-agency, cross-year aggregations and spatial queries (DuckDB spatial extension). This is both the production API for the frontend and, via an MCP wrapper, the developer query tool. One implementation, two consumers.
 
-**DuckDB MCP server** — the same DuckDB interface exposed as an MCP tool, used during development and data exploration. A single implementation serves both the developer agent (for querying data mid-task) and potentially the frontend itself. Run locally against `data/processed/*.parquet` or remotely against `releases/vN/` on S3.
+**MCP server** — the Lambda function is also exposed as an MCP tool during development. Agents can query the data mid-task (e.g., "show me stops for Belle PD 2014–2019") without materializing assets or writing one-off scripts. Run locally against `data/processed/*.parquet`; point at `releases/vN/` for production data.
 
-**DuckDB WASM** (under consideration) — query Parquet directly from the browser. Eliminates the Lambda layer for read-only queries; requires careful Parquet partitioning and acceptable cold-start times. Best suited for power-user / download features rather than the main editorial interface.
-
-Key design choice: **partition Parquet by year** at layer 3. DuckDB's partition pruning means a query for a single agency's 2024 data only scans the 2024 partition, not the full 11-year corpus.
+Key design choice: **partition Parquet by year** at layer 3. DuckDB's partition pruning means a query for a single agency's 2024 data only scans the 2024 partition, not the full corpus.
 
 ### Data-derived frontend artifacts
 

--- a/agents.md
+++ b/agents.md
@@ -37,3 +37,72 @@ The pipeline covers 2014–present across two distinct PDF formats (pre-2020 and
 - Python 3.12+; `uv sync` to install deps
 - `uv run dagster dev` to start the Dagster UI
 - Copy `.env.example` to `.env` and fill in AWS credentials (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_DEFAULT_REGION`, `MISSOURI_VSR_BUCKET_NAME`, `MISSOURI_VSR_S3_PREFIX`)
+
+---
+
+## Architecture
+
+### Three-layer pipeline
+
+Data moves through three conceptually distinct layers. Keeping them separate is what makes the system reproducible, testable, and safe to evolve.
+
+```
+Layer 1 — Raw / parsed
+  Source PDFs → pdftotext → per-year DataFrames
+  Assets: download_reports, extract_pdf_data_{year}
+  Output: combined_output_{year}.parquet
+  Row keys: era-specific (pre-2020 uses key-indicators/vehicle-stop-stats/search-stats;
+            2020+ uses rates-by-race/number-of-stops-by-race/search-statistics)
+  Invariant: no interpretation, no normalization; values match the source PDF exactly
+
+Layer 2 — Normalized / processed
+  Combined across years → canonical metrics → ranks, percentiles, baselines
+  Assets: combine_all_reports, reports_with_rank_percentile,
+          statewide_slug_baselines, agency_reference, gis
+  Output: all_combined_output.parquet, reports_with_rank_percentile.parquet,
+          per-agency JSON under data/out/agency_year/
+  Row keys: both era-specific keys preserved AND a canonical_key column (planned)
+            that maps equivalent metrics across eras for cross-year analysis
+  Invariant: layer 1 outputs are never modified; normalization adds columns / rows
+
+Layer 3 — Released
+  Versioned snapshot promoted to S3 for frontend consumption
+  Assets: dist group (JSON/GeoJSON/PMTiles exports, manifests)
+  Output: releases/vN/ on S3 with a manifest.json describing schema version,
+          years covered, canonical metric definitions
+  Invariant: a released version is immutable; frontend pins to a version
+```
+
+**The era-coherence problem** (current active design question): Pre-2020 and 2020+ reports use different metric names for equivalent concepts. The planned solution is a `canonical_key` column populated at layer 2 from a crosswalk config — e.g., both `key-indicators--stops` (2014–2019) and `rates-by-race--totals--all-stops` (2020+) map to canonical key `stops`. Layer 1 is untouched; layer 2 gains cross-year query capability; layer 3 exposes only canonical metrics to the frontend.
+
+### Staging + release workflow
+
+```
+main branch          → layer 1/2 assets; no versioned release
+staging/vN/ on S3    → pipeline writes here; frontend smoke-tests against it
+releases/vN/ on S3   → promoted from staging; frontend pins here
+```
+
+A release is triggered manually after:
+1. All asset checks pass on main
+2. Frontend team has validated the staging build
+3. `manifest.json` is updated with schema version, year range, and changelog entry
+
+Patch releases (vN.x) are backward-compatible changes (new years added, bug fixes that don't change existing values). Minor/major releases require a frontend coordination window and deprecate the prior release after a transition period.
+
+### Testing strategy
+
+Asset checks are the primary regression gate. They run at two levels:
+
+**Per-year extract checks** (`extract_pdf_data_{year}`):
+- `schema` — DataFrame columns match the expected set for that era
+- `no_duplicate_row_keys` — no `(agency, row_key)` collisions within a year
+- `numeric_columns_parse` — all race columns contain parseable numbers
+- `row_expectations` — golden-file CSV (`data_checks/row_sanity_checks_{year}.csv`) with spot-checked agency/metric values verified against source PDFs
+
+**Combined asset checks** (`combine_all_reports`):
+- Schema, duplicate row_key/row_id checks across the full multi-year frame
+
+**Adding sanity check rows**: pick an agency, read its PDF page, verify the values, append to `data_checks/row_sanity_checks_{year}.csv`. The `checked` column is for human review tracking; all rows run regardless.
+
+Unit tests (`pytest`) cover normalization ops and processing helpers but not the PDF parser directly — parser regressions are caught via the golden-file checks above.

--- a/agents.md
+++ b/agents.md
@@ -78,20 +78,15 @@ Layer 3 — Released
 
 **The era-coherence problem** (current active design question): Pre-2020 and 2020+ reports use different metric names for equivalent concepts. The planned solution is a `canonical_key` column populated at layer 2 from a crosswalk config — e.g., both `key-indicators--stops` (2014–2019) and `rates-by-race--totals--all-stops` (2020+) map to canonical key `stops`. Layer 1 is untouched; layer 2 gains cross-year query capability; layer 3 exposes only canonical metrics to the frontend.
 
-### Staging + release workflow
+### Release workflow
 
-```
-main branch          → layer 1/2 assets; no versioned release
-staging/vN/ on S3    → pipeline writes here; frontend smoke-tests against it
-releases/vN/ on S3   → promoted from staging; frontend pins here
-```
+No formal staging environment. During active v2 development, outputs are published incrementally to `releases/v2/` on S3. The frontend stays pinned to v1 via the top-level `manifest.json` until a deliberate cutover. The version number is the signal; there's no separate staging path.
 
-A release is triggered manually after:
-1. All asset checks pass on main
-2. Frontend team has validated the staging build
-3. `manifest.json` is updated with schema version, year range, and changelog entry
+A release is cut by:
+1. All asset checks passing on main
+2. Updating the top-level `manifest.json` to point at the new version
 
-Patch releases (vN.x) are backward-compatible changes (new years added, bug fixes that don't change existing values). Minor/major releases require a frontend coordination window and deprecate the prior release after a transition period.
+Patch releases (vN.x) are backward-compatible: new years added, bug fixes that don't change existing values. Major releases require frontend coordination before the manifest is flipped.
 
 ### Testing strategy
 
@@ -121,16 +116,16 @@ Data releases follow semantic versioning (vMAJOR.MINOR):
 - **Major** — breaking schema change: columns renamed/removed, row_key structure changed, canonical metric definitions revised. Requires frontend coordination and a deprecation window for the prior major version.
 - **Minor** — backward-compatible addition: new years added, new canonical metrics added, new derived columns added. Frontend can adopt at its own pace.
 
+No formal staging environment. During active development, v2 is published incrementally to `releases/v2/` until it's ready — the version number is the signal. The frontend stays pinned to v1 until explicitly cut over.
+
 S3 layout:
 
 ```
 s3://{bucket}/
   releases/
-    v1/          ← current frozen release (2020–2024, era-specific row_keys)
-    v2/          ← next release (2014–2024, canonical_key layer added)
-  staging/
-    v2/          ← pipeline writes here; not safe for production frontend use
-  manifest.json  ← points to the current stable release version
+    v1/          ← frozen (2020–2024, era-specific row_keys)
+    v2/          ← live development target; incremented until ready
+  manifest.json  ← points to the current frontend-facing release
 ```
 
 Each release directory contains a `manifest.json`:
@@ -146,7 +141,7 @@ Each release directory contains a `manifest.json`:
 }
 ```
 
-The frontend reads `manifest.json` to discover the current release and can hard-pin to a specific version for stability.
+The top-level `manifest.json` points to the current frontend-facing version. Updating it is the release act.
 
 ### Major migrations + milestones
 
@@ -223,7 +218,9 @@ The University of Missouri researchers who build the report get the pre-computed
 
 Computing from raw counts for pre-2020 also lets us substitute ACS population for 2010 census population once those figures are sourced (a future task), and gives us citation rate for free even though the AG didn't surface it.
 
-Stop rate and resident stop rate remain 2020+-only until pre-2020 ACS population figures are available.
+Stop rate and resident stop rate are 2020+-only; pre-2020 ACS population is not a blocker for v2.
+
+**Editorial note on population-based rates:** Unlike crime statistics, traffic stop rates divided by residential population are methodologically limited — traffic through a place is not the same as who lives there. Population-based rates (stop rate, resident stop rate) are included because the reports provide them and they have analytical uses, but they should not be treated as the primary disparity measure. The resident vs. non-resident split in 2020+ is useful precisely because it partially addresses this, but it doesn't exist pre-2020 and there's no clean equivalent.
 
 The crosswalk config (to be implemented in v2) must flag which rates are available per year range so the frontend can conditionally show or suppress rate comparisons by year.
 

--- a/agents.md
+++ b/agents.md
@@ -2,9 +2,9 @@
 
 ## Overview
 
-This project extracts, normalizes, and publishes Missouri's annual Vehicle Stops Report (VSR). Agencies are obligated by statute to report aggregate information about a number of metrics relating to the reason and outcomes of stops, broken down by the driver's race. They report their data to Missouri Attorney General's office, who work with researchers at the University of Missouri to generate the stops report.
+This project extracts, normalizes, and publishes Missouri's annual Vehicle Stops Report (VSR). Agencies are obligated by a statute that went into effect in 2000 to report aggregate information about a number of metrics relating to the reason and outcomes of stops, broken down by the driver's race. They report their data to Missouri Attorney General's office, who work with researchers at the University of Missouri to generate the stops report.
 
-Recovered Factory, using code originally developed at The Marshall Project, is extractining, combining, enriching, and publishing this data.
+Recovered Factory, using code originally developed at The Marshall Project, is extracting, combining, enriching, and publishing this data.
 
 The pipeline covers 2014–present across two distinct PDF formats (pre-2020 and 2020+), ~600 law enforcement agencies. Primary outputs are versioned, structured data files consumed by a separate frontend application and perhaps more importantly, available for journalists, researchers, policy makers, and concerned citizens to download and analyze.
 
@@ -153,8 +153,9 @@ The top-level `manifest.json` points to the current frontend-facing version. Upd
 **v2.0 — planned** (2014–2024, cross-era normalization)
 - Pre-2020 data (2014–2019) added to pipeline
 - `canonical_key` column added at layer 2 mapping both eras to shared concept names
-- Layer 3 release exposes canonical metrics; era-specific row_keys remain available for audit/research use
-- DuckDB query layer introduced (see Data for Frontend)
+- Layer 3 dist output collapses on `canonical_key`: where a canonical equivalent exists, the era-specific source row_key is dropped. This matters because 2020+ already has duplicate coverage — the pre-computed rates and the raw counts both appear under different row_keys for the same concept. The dist output should be clean and canonical-only.
+- Era-specific row_keys remain available in the layer 2 processed Parquet for audit/research use
+- **The biggest single task: thorough canonical mapping.** The draft crosswalk table in this doc covers a handful of rows; the full mapping spans all ~50+ row_keys across both eras, including deciding which pre-2020 rows have no 2020+ equivalent and vice versa. This mapping process should be done carefully and verified against source PDFs before any code is written.
 - Requires: canonical metric crosswalk config, processed.py era-aware subset lists, frontend schema update
 
 **v3.0 — future** (TBD)
@@ -232,11 +233,13 @@ The crosswalk config will be the authoritative source; this table is a planning 
 
 ### Query layer
 
-The query layer — Lambda + DuckDB serving the frontend — lives in the frontend repo, not here. Query patterns change when the frontend changes; those two things should evolve together. This repo's job ends at producing well-structured, versioned Parquet files on S3.
+The query layer — Lambda + DuckDB serving the frontend — lives in the frontend repo, not here. Query patterns change when the frontend changes; those two things should evolve together. This repo's job ends at producing well-structured, versioned Parquet, CSV, JSON, and PMTiles files on S3.
 
 For local data exploration, DuckDB against `data/processed/*.parquet` is the expected tool. It handles the full dataset comfortably and requires no infrastructure. Anyone doing serious pipeline work will have the parquets locally already. A local MCP server pointed at those parquets is a one-liner and doesn't need to live in either repo.
 
 Key design choice for layer 3 outputs: **partition Parquet by year**. DuckDB's partition pruning means a query for a single agency's 2024 data only scans the 2024 partition, keeping the frontend Lambda fast even as the year range grows.
+
+Lambda cold starts are not a meaningful concern here: the function will be kept warm with a cron ping, responses are heavily cached, and the data doesn't change between pipeline runs. There's no need for short cache TTLs or aggressive Lambda optimization.
 
 ### Data-derived frontend artifacts
 

--- a/agents.md
+++ b/agents.md
@@ -1,57 +1,39 @@
-# Agent Guide
+# Missouri VSR — Architecture & Agent Guide
 
-Quick reference for future coding agents working on this Dagster pipeline that parses Missouri Vehicle Stops Report (VSR) PDFs into tidy data.
+## Overview
 
-## What this project does
-- Downloads per-year VSR PDFs (see `YEAR_URLS` in `missouri_vsr/assets/extract.py`) and stores them under `data/src/reports`.
-- Extracts tables via `pdftotext -layout` with a text-first parser (`extract_pdf_data_<year>` assets), normalizing rows into `agency`, `table`, `section`, `metric`, and race counts/rates plus `row_key`/`row_id`.
-- Combines per-year Parquet outputs (`data/processed/combined_output_<year>.parquet`) into a master Parquet + DataFrame (`combine_all_reports`), then pivots by row_key and emits per-agency JSON under `data/out/agency_year`. Also writes `data/out/report_dimensions.json` with unique table/section/metric ids.
-- `data/src/2025-05-05-post-law-enforcement-agencies-list.xlsx` is agency metadata to join via a crosswalk; the `agency_list` asset loads it and writes `data/processed/agency_list.parquet` for downstream joins.
+This project extracts, normalizes, and publishes Missouri's annual Vehicle Stops Report (VSR) — a state-mandated racial profiling dataset from the Missouri Attorney General's office — for use in an editorial web product at The Marshall Project.
 
-## Repo layout (essentials)
-- `missouri_vsr/assets/`: Asset modules (`extract.py`, `reports.py`, `processed.py`, `audit.py`, `agency_reference.py`).
-- `missouri_vsr/assets/extract.py`: PDF parsing logic (pdftotext layout parsing, section detection, metric identifiers).
-- `missouri_vsr/definitions/definitions.py`: Dagster `Definitions`; registers assets and resources.
-- `missouri_vsr/resources/resources.py`: S3, Airtable, Google Drive resources.
-- `run_configs/*.yaml`: Example Dagster run configs (e.g., S3 bucket/prefix, WSL low-memory).
-- `data/`: Local inputs/outputs (reports, processed parquet, JSON exports).
+The pipeline covers 2014–present across two distinct PDF formats (pre-2020 and 2020+), ~600 law enforcement agencies, and a growing span of years. Primary outputs are versioned, structured data files consumed by a separate frontend application.
 
-## Setup and execution
-- Python 3.12+, `uv` for env mgmt (`uv sync`).
-- Create `.env` (loaded by Dagster) for credentials:
-  - AWS: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_DEFAULT_REGION` (or `AWS_REGION`), plus `MISSOURI_VSR_BUCKET_NAME`, `MISSOURI_VSR_S3_PREFIX` for S3 uploads.
-  - Optional: `DAGSTER_HOME` to persist Dagster instance locally.
-  - Optional resources: Airtable and Google service account vars if used.
-- Run Dagster UI: `uv run dagster dev`.
-- CLI materialization: `uv run dagster asset materialize --select <asset_or_query> -m missouri_vsr.definitions`.
+**Design principles**
 
-## Operational notes
-- `pdftotext -layout` outputs are cached next to the PDFs as `*.layout.txt`; delete those files to force re-extraction.
-- Outputs may upload to S3 if the `s3` resource is configured or env vars are present; presigned URLs default to 45 days (`presigned_expiration`).
-- Uses `row_key` for pivoting; row_keys encode `table_id` + `section_id` + `metric_id` (e.g., `number-of-stops-by-race--citation-warning-violation--moving`). `row_id` is `<year>-<agency_slug>-<row_key>`. Per-agency JSON is row-based (flat rows with row_key + identifiers).
-- Keep an eye on PDF parsing heuristics (section detection, right-to-left numeric sniffing); adjust in `missouri_vsr/assets/extract.py` if tables shift.
-- Data directories are configured via resources: `data_dir_source`, `data_dir_report_pdfs`, `data_dir_processed`, `data_dir_out` (see `definitions.py`).
+- *Extract close to source.* Raw parsing preserves the original report's structure, metric names, and values without interpretation. Normalization is a separate, explicit layer.
+- *Reproducible by re-run.* Every output can be regenerated from source PDFs and config files in this repo.
+- *Checks at the seam.* Parser regressions are caught at the per-year extract layer before downstream assets run.
+- *Stable contracts.* The frontend pins to a versioned data release. Pipeline changes that affect outputs increment the release version rather than silently breaking consumers.
+- *Agent-friendly.* The repo is structured so that AI coding agents working on the pipeline and on the frontend can operate independently against a shared data contract, minimizing coordination overhead.
 
-## Data checks (csv-driven queue)
-- `data_checks/row_sanity_checks.csv` drives per-year aggregate checks against `combine_all_reports`, matching on `row_key`, `agency`, and `year`, then asserting provided numeric/metadata fields. Each check returns counts plus samples of missing/mismatched rows.
-- `checked` is for human review tracking only; checks still run for all rows.
-- Add more checks by appending rows to that CSV; columns are coerced to numbers where applicable.
-- Other checks in `asset_checks.py`: schema columns match, no duplicate `agency`+`row_key`+`year`, no duplicate `row_id`+`year`, and numeric columns parse.
+**Tech stack**
 
-## Dev runs
-- Default dev workflow typically materializes everything, but you can select subsets in Dagster (e.g., a single `download_reports` output or one `extract_pdf_data_<year>` asset) and tune `VSR_PAGE_CHUNK_SIZE` to process smaller page chunks.
-- `download_reports` honors `context.selected_output_names` to choose specific years even though `YEAR_URLS` is hard-coded; use asset selection in Dagster UI/CLI to leverage this.
-- You can override PDF inputs by pointing the `data_dir_report_pdfs` resource at a directory containing example PDFs (e.g., a trimmed 2023 sample) instead of downloading from `YEAR_URLS`.
-- Bundled sample: `data/src/examples/VSRreport2023.pdf` (pages 1694–1745). Run with `run_configs/example_2023_sample.yaml` and `--select extract_pdf_data_2023` to stay on the sample.
+- Dagster 1.x — orchestration (no schedules; batch on-demand)
+- pandas / pyarrow — data wrangling
+- pdftotext -layout (poppler-utils) — primary PDF extraction
+- DuckDB — query layer for data exploration and (planned) API
+- GeoPandas + tippecanoe — GIS / PMTiles
+- S3 — versioned output distribution
 
-## Agency crosswalk CLI
-- Script: `python -m missouri_vsr.cli.crosswalk` (run via `uv run …`).
-- Defaults: reads agency metadata from `data/processed/agency_list.parquet` (or Excel fallback), VSR candidates from `data/processed/all_combined_output.parquet`, writes `data/src/agency_crosswalk.csv`, and optional merged join to `data/processed/agency_reference.parquet`.
-- Auto-picks a name column unless `--name-col` is set; uses fuzzy suggestions from VSR “agency” values. Auto-accepts exact normalized matches.
-- Interactive controls: pick a suggestion; `n` mark “not in VSR” (blank canonical); `s` skip for later (leave unresolved); `m` more; `b` back; `q` save/quit. Progress autosaves crosswalk + `.state.json` (same dir) for resume.
-- Crosswalk is still evolving; current spreadsheet columns are in flux—don’t overfit.
+**Repo layout (essentials)**
 
-## Open questions for the human
-- Should we document or check in sample/example PDFs for quick regression runs, or always hit the live AGO URLs?
-- Is there a preferred minimal asset selection to run during development (e.g., a single year) and a standard run config we should default to in commands?
-- Any additional external resources (Airtable/Drive) we expect to wire in soon that should be captured here?
+- `missouri_vsr/assets/` — Asset modules (`extract.py`, `reports.py`, `processed.py`, `audit.py`, `agency_reference.py`, `gis.py`)
+- `missouri_vsr/asset_checks/` — Per-year and combined asset checks
+- `missouri_vsr/definitions/` — Dagster `Definitions`; registers assets and resources
+- `data_checks/` — CSV-driven row sanity checks per year
+- `run_configs/` — Example Dagster run configs
+- `data/` — Local inputs/outputs (reports, processed parquet, JSON exports)
+
+**Setup**
+
+- Python 3.12+; `uv sync` to install deps
+- `uv run dagster dev` to start the Dagster UI
+- Copy `.env.example` to `.env` and fill in AWS credentials (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_DEFAULT_REGION`, `MISSOURI_VSR_BUCKET_NAME`, `MISSOURI_VSR_S3_PREFIX`)

--- a/agents.md
+++ b/agents.md
@@ -191,13 +191,24 @@ The data contract defines what the frontend can rely on across releases. It live
 
 **On arrests:** `key-indicators--arrests` (pre-2020) and `number-of-stops-by-race--stop-outcome--arrests` (2020+) measure the same thing and can be treated as equivalent in cross-era analysis.
 
-**On rates — the hard part:** This is where the eras diverge most interestingly. Pre-2020 reports pre-compute a small set of rates directly in the PDF (`key-indicators--search-rate`, `key-indicators--contraband-hit-rate`, `key-indicators--arrest-rate`). The 2020+ format drops the pre-computed rates in favor of raw counts, from which more rates can be derived — including citation rate and stop rate vs. ACS population, which have no pre-2020 equivalent. So:
+**On rates — the hard part:** The 2020+ format defines the canonical set of six rates we need. Their denominators matter:
 
-- `search-rate`, `contraband-hit-rate`, `arrest-rate`: present in both eras but sourced differently (pre-2020: pre-computed percentage; 2020+: derived from raw count rows)
-- `citation-rate`, `stop-rate` (vs. ACS population): 2020+ only — these comparisons cannot be made for pre-2020 years
-- The older format is better structured and more uniform in many respects; the newer format is richer analytically
+| rate | formula | pre-2020 | 2020+ |
+|---|---|---|---|
+| Stop rate | stops / prev-year ACS pop × 100 | ✗ no ACS population data | ✓ derived from raw counts |
+| Resident stop rate | resident stops / prev-year ACS pop × 100 | ✗ no ACS data, no resident split | ✓ derived from raw counts |
+| Search rate | searches / stops × 100 | ✓ pre-computed in PDF | ✓ derived from raw counts |
+| Contraband hit rate | searches w/ contraband / total searches × 100 | ✓ pre-computed in PDF | ✓ derived from raw counts |
+| Arrest rate | arrests / stops × 100 | ✓ pre-computed in PDF | ✓ derived from raw counts |
+| Citation rate | citations / stops × 100 | derivable (raw counts exist) | ✓ derived from raw counts |
 
-The crosswalk config (to be implemented in v2) will need to flag which rates are available per year range, so the frontend can conditionally show or suppress rate-based comparisons depending on the year selected.
+Key observations:
+- Stop rate and resident stop rate are 2020+ only. They require ACS population as the denominator — a methodological choice that makes them the most analytically interesting rates, and which pre-2020 reports simply don't support.
+- Search rate, contraband hit rate, and arrest rate exist in both eras but are sourced differently: pre-2020 gives them pre-computed as percentages in the PDF; 2020+ stores raw counts and derives them at layer 2.
+- Citation rate is technically derivable for pre-2020 (raw citation and stop counts both exist), but it was not a rate the older reports surfaced directly.
+- The pre-2020 format is better structured and more predictable in many respects; 2020+ is analytically richer.
+
+The crosswalk config (to be implemented in v2) must flag which rates are available per year range so the frontend can conditionally show or suppress rate comparisons by year.
 
 The crosswalk config will be the authoritative source; this table is a planning aid.
 

--- a/agents.md
+++ b/agents.md
@@ -2,17 +2,20 @@
 
 ## Overview
 
-This project extracts, normalizes, and publishes Missouri's annual Vehicle Stops Report (VSR) — a state-mandated racial profiling dataset from the Missouri Attorney General's office — for use in an editorial web product at The Marshall Project.
+This project extracts, normalizes, and publishes Missouri's annual Vehicle Stops Report (VSR). Agencies are obligated by statute to report aggregate information about a number of metrics relating to the reason and outcomes of stops, broken down by the driver's race. They report their data to Missouri Attorney General's office, who work with researchers at the University of Missouri to generate the stops report.
 
-The pipeline covers 2014–present across two distinct PDF formats (pre-2020 and 2020+), ~600 law enforcement agencies, and a growing span of years. Primary outputs are versioned, structured data files consumed by a separate frontend application.
+Recovered Factory, using code originally developed at The Marshall Project, is extractining, combining, enriching, and publishing this data.
+
+The pipeline covers 2014–present across two distinct PDF formats (pre-2020 and 2020+), ~600 law enforcement agencies. Primary outputs are versioned, structured data files consumed by a separate frontend application and perhaps more importantly, available for journalists, researchers, policy makers, and concerned citizens to download and analyze.
 
 **Design principles**
 
 - *Extract close to source.* Raw parsing preserves the original report's structure, metric names, and values without interpretation. Normalization is a separate, explicit layer.
-- *Reproducible by re-run.* Every output can be regenerated from source PDFs and config files in this repo.
-- *Checks at the seam.* Parser regressions are caught at the per-year extract layer before downstream assets run.
+- *Reproducible by re-running.* Every output can be deterministically regenerated from source PDFs and config files in this repo.
+- *Checks at each stage.* Parser regressions and data quality issues are caught at the per-year extract layer before downstream assets run and rely _heavily_ on Dagster asset checks; downstream asset checks (like data transformations) are more focused and use a mix of asset checks and unit tests.  
 - *Stable contracts.* The frontend pins to a versioned data release. Pipeline changes that affect outputs increment the release version rather than silently breaking consumers.
 - *Agent-friendly.* The repo is structured so that AI coding agents working on the pipeline and on the frontend can operate independently against a shared data contract, minimizing coordination overhead.
+- *Entirely backend.* APIs, microservices, and anything other than the most basic file outputs should live elsewhere.
 
 **Tech stack**
 

--- a/agents.md
+++ b/agents.md
@@ -191,22 +191,33 @@ The data contract defines what the frontend can rely on across releases. It live
 
 **On arrests:** `key-indicators--arrests` (pre-2020) and `number-of-stops-by-race--stop-outcome--arrests` (2020+) measure the same thing and can be treated as equivalent in cross-era analysis.
 
-**On rates — the hard part:** The 2020+ format defines the canonical set of six rates we need. Their denominators matter:
+**On rates:** Both eras pre-compute per-agency rates directly in the PDF. The eras differ in which rates are present and what population source is used.
 
-| rate | formula | pre-2020 | 2020+ |
-|---|---|---|---|
-| Stop rate | stops / prev-year ACS pop × 100 | ✗ no ACS population data | ✓ derived from raw counts |
-| Resident stop rate | resident stops / prev-year ACS pop × 100 | ✗ no ACS data, no resident split | ✓ derived from raw counts |
-| Search rate | searches / stops × 100 | ✓ pre-computed in PDF | ✓ derived from raw counts |
-| Contraband hit rate | searches w/ contraband / total searches × 100 | ✓ pre-computed in PDF | ✓ derived from raw counts |
-| Arrest rate | arrests / stops × 100 | ✓ pre-computed in PDF | ✓ derived from raw counts |
-| Citation rate | citations / stops × 100 | derivable (raw counts exist) | ✓ derived from raw counts |
+Pre-2020 rates (from key-indicators, using 2010 decennial census population):
 
-Key observations:
-- Stop rate and resident stop rate are 2020+ only. They require ACS population as the denominator — a methodological choice that makes them the most analytically interesting rates, and which pre-2020 reports simply don't support.
-- Search rate, contraband hit rate, and arrest rate exist in both eras but are sourced differently: pre-2020 gives them pre-computed as percentages in the PDF; 2020+ stores raw counts and derives them at layer 2.
-- Citation rate is technically derivable for pre-2020 (raw citation and stop counts both exist), but it was not a rate the older reports surfaced directly.
-- The pre-2020 format is better structured and more predictable in many respects; 2020+ is analytically richer.
+| rate | formula |
+|---|---|
+| Disparity index | (proportion of stops / proportion of population) — value of 1 = no disparity |
+| Search rate | searches / stops × 100 |
+| Contraband hit rate | searches with contraband / total searches × 100 |
+| Arrest rate | arrests / stops × 100 |
+
+Note: pre-2020 reports include a "% of population" row per agency (statewide and local), which means the implied census population figures can be back-calculated from the data if needed.
+
+2020+ rates (from rates-by-race--rates--, using previous-year ACS population for the stop-rate denominators):
+
+| rate | formula |
+|---|---|
+| Stop rate | stops / ACS population × 100 |
+| Resident stop rate | resident stops / ACS population × 100 |
+| Search rate | searches / stops × 100 |
+| Contraband hit rate | searches with contraband / total searches × 100 |
+| Arrest rate | arrests / stops × 100 |
+| Citation rate | citations / stops × 100 |
+
+**Open design question — compute rates uniformly at layer 2?**
+
+The raw counts needed to derive search rate, arrest rate, and contraband hit rate exist in both eras. Citation rate raw counts also exist pre-2020 (`vehicle-stop-stats--stop-outcome--citation` / `key-indicators--stops`). This raises the option of discarding the pre-computed rates from both eras and recomputing everything consistently at layer 2 — once canonical_key normalization is in place. Benefits: identical methodology across 2014–2024, ability to substitute ACS population for census population in pre-2020 years when that data is available. The stop rate and resident stop rate would remain 2020+-only until pre-2020 ACS population figures are sourced.
 
 The crosswalk config (to be implemented in v2) must flag which rates are available per year range so the frontend can conditionally show or suppress rate comparisons by year.
 

--- a/agents.md
+++ b/agents.md
@@ -106,3 +106,84 @@ Asset checks are the primary regression gate. They run at two levels:
 **Adding sanity check rows**: pick an agency, read its PDF page, verify the values, append to `data_checks/row_sanity_checks_{year}.csv`. The `checked` column is for human review tracking; all rows run regardless.
 
 Unit tests (`pytest`) cover normalization ops and processing helpers but not the PDF parser directly — parser regressions are caught via the golden-file checks above.
+
+---
+
+## Data + Release
+
+### Release / version strategy
+
+Data releases follow semantic versioning (vMAJOR.MINOR):
+
+- **Major** — breaking schema change: columns renamed/removed, row_key structure changed, canonical metric definitions revised. Requires frontend coordination and a deprecation window for the prior major version.
+- **Minor** — backward-compatible addition: new years added, new canonical metrics added, new derived columns added. Frontend can adopt at its own pace.
+
+S3 layout:
+
+```
+s3://{bucket}/
+  releases/
+    v1/          ← current frozen release (2020–2024, era-specific row_keys)
+    v2/          ← next release (2014–2024, canonical_key layer added)
+  staging/
+    v2/          ← pipeline writes here; not safe for production frontend use
+  manifest.json  ← points to the current stable release version
+```
+
+Each release directory contains a `manifest.json`:
+
+```json
+{
+  "version": "2.0",
+  "released": "YYYY-MM-DD",
+  "years": [2014, 2015, ..., 2024],
+  "schema_version": "2.0",
+  "canonical_metrics": ["stops", "searches", "arrests", ...],
+  "changelog": "Added 2014–2019 pre-2020 format data with canonical_key normalization."
+}
+```
+
+The frontend reads `manifest.json` to discover the current release and can hard-pin to a specific version for stability.
+
+### Major migrations + milestones
+
+**v1.0 — current** (2020–2024, 2020+ format only)
+- Per-year extract assets with asset checks
+- Era-specific row_keys (`rates-by-race--*`, `number-of-stops-by-race--*`, `search-statistics--*`)
+- S3 flat-file outputs, per-agency JSON
+
+**v2.0 — planned** (2014–2024, cross-era normalization)
+- Pre-2020 data (2014–2019) added to pipeline
+- `canonical_key` column added at layer 2 mapping both eras to shared concept names
+- Layer 3 release exposes canonical metrics; era-specific row_keys remain available for audit/research use
+- DuckDB query layer introduced (see Data for Frontend)
+- Requires: canonical metric crosswalk config, processed.py era-aware subset lists, frontend schema update
+
+**v3.0 — future** (TBD)
+- May include: additional years as AG publishes, revised ACS population vintages, expanded GIS outputs
+
+### Data contract
+
+The data contract defines what the frontend can rely on across releases. It lives in this file and is the coordination point when pipeline and frontend agents work in parallel.
+
+**Stable across all versions:**
+- Core tidy row schema: `year`, `agency`, `row_key`, `row_id`, `table_id`, `section_id`, `metric_id`, plus race count columns
+- Race columns (2020+): `Total`, `White`, `Black`, `Hispanic`, `Native American`, `Asian`, `Other`
+- Race columns (pre-2020): `Total`, `White`, `Black`, `Hispanic`, `Asian`, `Am. Indian`, `Other`
+- `row_key` pattern: `{table_id}--{section_id}--{metric_id}`
+- `row_id` pattern: `{year}-{agency_slug}-{row_key}`
+
+**Added in v2:**
+- `canonical_key` — era-independent concept name (e.g., `stops`, `searches`, `arrests`, `moving-violation`, `consent-search`). Null for metrics with no cross-era equivalent.
+
+**Canonical metric crosswalk (draft — v2 design):**
+
+| canonical_key | pre-2020 row_key | 2020+ row_key |
+|---|---|---|
+| `stops` | `key-indicators--stops` | `rates-by-race--totals--all-stops` |
+| `searches` | `key-indicators--searches` | `rates-by-race--totals--searches` |
+| `arrests` | `key-indicators--arrests` | `number-of-stops-by-race--stop-outcome--arrests` |
+| `moving-violation` | `vehicle-stop-stats--reason-for-stop--moving` | `number-of-stops-by-race--reason-for-stop--moving` |
+| `consent-search` | `search-stats--probable-cause-authority-to-search--consent` | `search-statistics--probable-cause--consent` |
+
+Note: some 2020+ metrics have no pre-2020 equivalent (resident-only stops, ACS population rows, citation rate) and vice versa (pre-2020 bakes search rate and contraband hit rate directly; 2020+ derives them from raw counts). The crosswalk config will be the authoritative source; this table is a planning aid.

--- a/agents.md
+++ b/agents.md
@@ -215,3 +215,34 @@ The pipeline can generate frontend-facing content directly from data and schema,
 **Agency year index** — a lightweight JSON index of `{agency, years_available, canonical_metrics_available}` that lets the frontend quickly determine what to show before fetching the full agency data.
 
 **Schema changelog** — each manifest.json entry includes a human-readable changelog that the frontend can surface in a "what changed" UI, linking data version to editorial context.
+
+---
+
+## Development
+
+### Multi-agent setup
+
+The pipeline repo and frontend repo are kept separate — different toolchains, different deployment cadences. The coordination point between agents working on each side is the **data contract** section of this file and the `manifest.json` in each release.
+
+**Running two agents in parallel:**
+
+- Open one Claude Code session in the pipeline repo, one in the frontend repo
+- Give both sessions the relevant section of this file as context (paste or reference `agents.md`)
+- Define the change in terms of the data contract first — agree on what layer 3 will emit before either agent writes code
+- Pipeline agent works against `staging/vN/`; frontend agent works against the same staging path
+- Neither agent needs to understand the other repo's internals — only the contract matters
+
+**CLAUDE.md and memory:** Each repo has its own `CLAUDE.md` and per-project memory. The pipeline memory (`.claude/projects/.../memory/`) captures parser quirks, feedback, and project state that would otherwise be re-derived every session. Frontend repo should have equivalent memory for its own domain.
+
+**Branch and PR conventions:**
+- Feature branches are named `issue-{N}-{short-description}`
+- PRs close the issue they're tied to; commit messages reference the agent co-author
+- `agents.md` changes that affect the data contract should be committed and pushed before the implementing PR is opened, so both repos can reference the same contract version
+
+**Operational notes for agents:**
+- `pdftotext -layout` outputs are cached next to PDFs as `*.layout.txt`; delete to force re-extraction
+- S3 uploads happen only when the `s3` resource is configured; local runs skip upload silently
+- `row_key` encodes `{table_id}--{section_id}--{metric_id}`; `row_id` is `{year}-{agency_slug}-{row_key}`
+- Pre-2020 parser uses `_parse_pre2020_pdftotext_lines`; 2020+ uses the main state machine in `extract.py`
+- Sample PDF for fast dev iteration: `data/src/examples/VSRreport2023.pdf` (pages 1694–1745); use `run_configs/example_2023_sample.yaml` with `--select extract_pdf_data_2023`
+- Agency crosswalk CLI: `uv run python -m missouri_vsr.cli.crosswalk` — interactive fuzzy-match tool for resolving agency name variations; progress autosaves to `.state.json`

--- a/agents.md
+++ b/agents.md
@@ -235,13 +235,11 @@ The crosswalk config will be the authoritative source; this table is a planning 
 
 ### Query layer
 
-The flat-file / per-agency JSON approach works well for a single year but becomes unwieldy at 20+ years. The assumed query layer is **DuckDB on S3 Parquet, served via AWS Lambda**. Traffic is currently light enough that Lambda cold starts are acceptable and the operational simplicity outweighs the latency cost of a persistent server.
+The query layer — Lambda + DuckDB serving the frontend — lives in the frontend repo, not here. Query patterns change when the frontend changes; those two things should evolve together. This repo's job ends at producing well-structured, versioned Parquet files on S3.
 
-**Lambda + DuckDB** — a thin Lambda function wraps DuckDB queries against versioned Parquet files on S3. Returns JSON. Handles cross-agency, cross-year aggregations and spatial queries (DuckDB spatial extension). This is both the production API for the frontend and, via an MCP wrapper, the developer query tool. One implementation, two consumers.
+For local data exploration, DuckDB against `data/processed/*.parquet` is the expected tool. It handles the full dataset comfortably and requires no infrastructure. Anyone doing serious pipeline work will have the parquets locally already. A local MCP server pointed at those parquets is a one-liner and doesn't need to live in either repo.
 
-**MCP server** — the Lambda function is also exposed as an MCP tool during development. Agents can query the data mid-task (e.g., "show me stops for Belle PD 2014–2019") without materializing assets or writing one-off scripts. Run locally against `data/processed/*.parquet`; point at `releases/vN/` for production data.
-
-Key design choice: **partition Parquet by year** at layer 3. DuckDB's partition pruning means a query for a single agency's 2024 data only scans the 2024 partition, not the full corpus.
+Key design choice for layer 3 outputs: **partition Parquet by year**. DuckDB's partition pruning means a query for a single agency's 2024 data only scans the 2024 partition, keeping the frontend Lambda fast even as the year range grows.
 
 ### Data-derived frontend artifacts
 

--- a/agents.md
+++ b/agents.md
@@ -215,9 +215,15 @@ Note: pre-2020 reports include a "% of population" row per agency (statewide and
 | Arrest rate | arrests / stops × 100 |
 | Citation rate | citations / stops × 100 |
 
-**Open design question — compute rates uniformly at layer 2?**
+**Design decision — compute rates uniformly at layer 2**
 
-The raw counts needed to derive search rate, arrest rate, and contraband hit rate exist in both eras. Citation rate raw counts also exist pre-2020 (`vehicle-stop-stats--stop-outcome--citation` / `key-indicators--stops`). This raises the option of discarding the pre-computed rates from both eras and recomputing everything consistently at layer 2 — once canonical_key normalization is in place. Benefits: identical methodology across 2014–2024, ability to substitute ACS population for census population in pre-2020 years when that data is available. The stop rate and resident stop rate would remain 2020+-only until pre-2020 ACS population figures are sourced.
+For v2, rates will be computed from raw counts at layer 2 for all years rather than using the pre-computed values from the PDFs. This gives a single consistent methodology across 2014–2024.
+
+For 2020+, the University of Missouri researchers who build the report get the pre-computed rates right. This means our computed rates should match the PDF values exactly — which doubles as a validation check on our raw count extraction. Any mismatch between our computed rate and the PDF's pre-computed value signals a parsing error in the underlying counts.
+
+For pre-2020, computing from raw counts also lets us substitute ACS population for 2010 census population once those figures are sourced (a future task), and gives us citation rate for free even though the AG didn't surface it.
+
+Stop rate and resident stop rate remain 2020+-only until pre-2020 ACS population figures are available.
 
 The crosswalk config (to be implemented in v2) must flag which rates are available per year range so the frontend can conditionally show or suppress rate comparisons by year.
 


### PR DESCRIPTION
## Summary

- Replaces the old quick-reference `agents.md` with a full architecture and agent guide
- Covers the three-layer pipeline, staging/release workflow, testing strategy, data versioning, the cross-era normalization problem (v2 design), query layer (Lambda + DuckDB + MCP), and multi-agent development workflow
- Commits one section at a time per project convention
- Documents the canonical metric crosswalk draft including the rates complexity: pre-2020 pre-computes search/contraband/arrest rates; 2020+ derives more rates (citation rate, stop rate vs ACS population) from raw counts — not all rates are available across all years
- Assumes Lambda as the MCP and API substrate given current traffic scale

This is a living document — fussy crosswalk details, frontend-specific artifacts, and migration milestones will be filled in as v2 work proceeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)