### PR TITLE
Carry AgencyType through to agency_index dist output

### DIFF
--- a/missouri_vsr/assets/processed.py
+++ b/missouri_vsr/assets/processed.py
@@ -806,6 +806,7 @@ def build_agency_index_records(
                 "zip": None,
                 "phone": None,
                 "county": None,
+                "agency_type": None,
                 "census_geoid": None,
                 metric_row_key: None,
                 metric_alias: None,


### PR DESCRIPTION
`AgencyType` (Municipal, County, University, State Agency, etc.) was already present in `agency_reference_geocoded` but was silently dropped in `build_agency_index_records` — it was never added to the entry dict.

Adds `agency_type` field to every agency index record. Agencies with no match in the state reference list get `null`.

## Test plan
- [x] Materialize `agency_index_json` and confirm `agency_type` appears in `data/out/agency_index.json`
- [x] `pytest` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)