### PR TITLE
Drop cross-rate pairing keys from manifest.canonical_metrics

### DIFF
--- a/missouri_vsr/assets/processed.py
+++ b/missouri_vsr/assets/processed.py
@@ -35,6 +35,29 @@ DOWNLOAD_PREFIX = f"missouri_vsr_{min(YEAR_URLS)}_{max(YEAR_URLS)}_"
 # Row_keys excluded from metric_year_subset (not user-facing in the homepage picker).
 # Anything else present in the canonical combined parquet will be emitted.
 METRIC_YEAR_SUBSET_EXCLUDE_PREFIXES = ("rates-population",)
+
+# Cross-rate pairings (e.g. "stop-rate-residents--arrest-rate") are scatter-chart
+# inputs only — they're kept in metric_year_subset/{key}.json so the scatter
+# components can read them by name, but excluded from manifest.canonical_metrics
+# so they don't surface in the homepage picker.
+_RATE_HALVES = {
+    "search-rate",
+    "arrest-rate",
+    "contraband-hit-rate",
+    "stop-rate",
+    "citation-rate",
+    "stop-rate-residents",
+}
+
+
+def _is_cross_rate_pairing(key: str) -> bool:
+    """True iff key is a top-level pairing of two rate-shaped halves (X--Y)."""
+    if "--" not in key:
+        return False
+    parts = key.split("--")
+    if len(parts) != 2:
+        return False
+    return all(p in _RATE_HALVES or p.endswith("-rate") for p in parts)
 STATEWIDE_SUMS_SUBSET_KEYS = [
     # Canonical keys (post-collapse row_key = canonical_key)
     "stops",
@@ -2421,7 +2444,7 @@ def dist_manifest_json(context) -> str:
     con.close()
 
     years = [int(r[0]) for r in years_rows]
-    canonical_metrics = [r[0] for r in canonical_rows]
+    canonical_metrics = [r[0] for r in canonical_rows if not _is_cross_rate_pairing(r[0])]
 
     manifest = {
         "version": "2.0",


### PR DESCRIPTION
## Summary
- Fixes #23. Six cross-rate pairing keys (`X--Y` where both halves are rate-shaped — `contraband-hit-rate--arrest-rate`, `stop-rate-residents--search-rate`, etc.) were leaking into the homepage picker after #21.
- Filter them out of `dist_manifest_json`'s `canonical_metrics` using a structural rule: contains `--` and both halves are in the rate set `{search-rate, arrest-rate, contraband-hit-rate, stop-rate, citation-rate, stop-rate-residents}` or end with `-rate`. Detection helper unit-tested against the 6 targets and 7 counter-examples (`arrest-charge--*`, `disparity-index--*`, `reason-for-stop--moving`, etc.) — none misfire.
- **Keep** the keys in `metric_year_subset/{key}.json` and per-year rollups so scatter charts still have the data.

## Already deployed
- `dist_manifest_json` rematerialized; `manifest.json` auto-uploaded to `s3://vsr-data.grupovisual.org/releases/v2/manifest.json` with 116 canonical metrics.
- `metric_year_subset` untouched (still has all 110 keys including the 6).

## Test plan
- [x] `manifest.json:canonical_metrics.length` = 116 (was 122)
- [x] None of the 6 cross-rate pairs appear in `canonical_metrics`
- [x] `metric_year_subset/_index.json:row_keys.length` = 110 (unchanged)
- [x] All 6 cross-rate keys still listed in `_index.json:row_keys`
- [x] `stop-rate-residents--arrest-rate.json` still exists with rows (74 agency-years)
- [ ] Picker hides "Stop Rate Residents" / "Contraband Hit Rate" sub-sections after frontend filters against `canonical_metrics` and CDN invalidates

🤖 Generated with [Claude Code](https://claude.com/claude-code)