### PR TITLE
Add wide-format CSV download bundle (#16)

### DIFF
--- a/missouri_vsr/assets/processed.py
+++ b/missouri_vsr/assets/processed.py
@@ -669,6 +669,37 @@ def pivot_reports_by_slug_op(context, combined: pd.DataFrame) -> pd.DataFrame:
     return pivoted
 
 
+_WIDE_RACE_SLUGS = {
+    "Total": "total",
+    "White": "white",
+    "Black": "black",
+    "Hispanic": "hispanic",
+    "Native American": "native_american",
+    "Asian": "asian",
+    "Other": "other",
+}
+
+
+def _flatten_to_wide_columns(pivoted: pd.DataFrame) -> pd.DataFrame:
+    """Rename columns from `{row_key}__{Race}` to `{flat_row_key}_{race_slug}`.
+
+    `flat_row_key` replaces row_key's `--` hierarchy markers and inner `-`s with
+    `_`. Race names are lowercased and spaces become underscores. Leaves the
+    `agency` and `year` index columns untouched.
+    """
+    def rename(col: str) -> str:
+        if col in ("agency", "year"):
+            return col
+        rk, _, race = col.rpartition("__")
+        if not rk:
+            return col
+        rk_flat = rk.replace("--", "_").replace("-", "_").lower()
+        race_slug = _WIDE_RACE_SLUGS.get(race, race.lower().replace(" ", "_"))
+        return f"{rk_flat}_{race_slug}"
+
+    return pivoted.rename(columns=rename)
+
+
 @asset(
     name="pivot_reports_by_slug",
     group_name="processed",
@@ -1580,11 +1611,13 @@ def _write_download_bundle(
     *,
     base_name: str,
     out_dir: Path,
+    prefix_override: str | None = None,
 ) -> dict:
     out_dir.mkdir(parents=True, exist_ok=True)
-    parquet_path = out_dir / f"{DOWNLOAD_PREFIX}{base_name}.parquet"
-    csv_path = out_dir / f"{DOWNLOAD_PREFIX}{base_name}.csv"
-    legacy_json = out_dir / f"{DOWNLOAD_PREFIX}{base_name}.json"
+    prefix = prefix_override if prefix_override is not None else DOWNLOAD_PREFIX
+    parquet_path = out_dir / f"{prefix}{base_name}.parquet"
+    csv_path = out_dir / f"{prefix}{base_name}.csv"
+    legacy_json = out_dir / f"{prefix}{base_name}.json"
 
     df.to_parquet(parquet_path, index=False, engine="pyarrow")
     df.to_csv(csv_path, index=False)
@@ -2713,6 +2746,44 @@ def downloads_combined(context) -> dict:
     agency_ref = pd.read_parquet(processed_dir / "agency_reference_geocoded.parquet")
     agency_comments = pd.read_parquet(processed_dir / "agency_comments.parquet")
     return write_downloads_combined(context, reports, stops_rows, agency_ref, reports, agency_comments)
+
+
+@asset(
+    name="downloads_wide",
+    group_name="downloads",
+    deps=[AssetKey("combine_all_reports")],
+    required_resource_keys={"data_dir_processed", "data_dir_out", "s3"},
+    description=(
+        "Wide-format download bundle: one row per agency-year with columns "
+        "flattened as `<row_key>_<race>` (e.g. `stops_black`, "
+        "`rates_by_race_population_density_white`). Emits an all-years CSV+parquet "
+        "plus one per-year CSV+parquet slice."
+    ),
+)
+def downloads_wide(context) -> dict:
+    processed_dir = Path(context.resources.data_dir_processed.get_path())
+    out_dir = Path(context.resources.data_dir_out.get_path()) / "downloads"
+    combined = pd.read_parquet(processed_dir / "all_combined_output.parquet")
+    pivoted = pivot_reports_by_slug_op(context, combined)
+    wide = _flatten_to_wide_columns(pivoted)
+    context.log.info("Wide pivot shape: %s rows × %s cols", *wide.shape)
+
+    results: dict = {
+        "all_years": _write_download_bundle(
+            context, wide, base_name="wide", out_dir=out_dir
+        )
+    }
+    for year in sorted(wide["year"].dropna().unique()):
+        year_int = int(year)
+        year_slice = wide[wide["year"] == year].drop(columns=["year"])
+        results[f"year_{year_int}"] = _write_download_bundle(
+            context,
+            year_slice,
+            base_name="wide",
+            out_dir=out_dir,
+            prefix_override=f"missouri_vsr_{year_int}_",
+        )
+    return results
 
 
 @asset(

--- a/missouri_vsr/assets/processed.py
+++ b/missouri_vsr/assets/processed.py
@@ -2786,6 +2786,11 @@ def downloads_wide(context) -> dict:
     return results
 
 
+_WIDE_FILENAME_RE = re.compile(
+    r"^missouri_vsr_(?P<start>\d{4})(?:_(?P<end>\d{4}))?_wide\.(?:csv|parquet)$"
+)
+
+
 @asset(
     name="downloads_manifest",
     group_name="downloads",
@@ -2795,6 +2800,7 @@ def downloads_wide(context) -> dict:
         AssetKey("downloads_agency_index"),
         AssetKey("downloads_agency_comments"),
         AssetKey("downloads_combined"),
+        AssetKey("downloads_wide"),
     ],
     description="Manifest of download bundle files with sizes.",
 )
@@ -2817,7 +2823,16 @@ def write_downloads_manifest(context) -> str:
         except OSError:
             size = None
         suffix = path.suffix.lower().lstrip(".")
-        entries.append({"path": rel, "size_bytes": size, "group": suffix or "unknown"})
+        entry = {"path": rel, "size_bytes": size, "group": suffix or "unknown"}
+
+        wide_match = _WIDE_FILENAME_RE.match(path.name)
+        if wide_match:
+            entry["format"] = "wide"
+            # Per-year files: only `start` is present. All-years: both `start` and `end`.
+            if wide_match.group("end") is None:
+                entry["year"] = int(wide_match.group("start"))
+
+        entries.append(entry)
 
     entries.sort(
         key=lambda item: (item["size_bytes"] is None, -(item["size_bytes"] or 0))


### PR DESCRIPTION
Closes #16. Closes #31.

Adds a `downloads_wide` asset that emits one row per agency-year with columns flattened as `<flat_row_key>_<race>`. Hierarchy from `row_key` is preserved (`--` → `_`, inner `-` → `_`, lowercased).

Follow-up commit `fcf4164` also includes the wide bundles in `downloads_manifest.json` with `format: "wide"` and per-year `year: <int>` tags (frontend ask in #31 / vsr-tool#201).

## Output

- `missouri_vsr_2000_2024_wide.{csv,parquet}` — ~15K rows × 1,450 cols, all years
- `missouri_vsr_{year}_wide.{csv,parquet}` × 25 — ~600 rows × 1,449 cols, per year

All land under `data/out/downloads/` and upload to `s3://vsr-data.grupovisual.org/releases/v2.1/downloads/`. Manifest entries are tagged so the frontend can drop its hardcoded URL stems and size constants from vsr-tool#201.

## Column examples

| row_key | flattened columns |
| --- | --- |
| `rates-by-race--totals--all-stops` | `rates_by_race_totals_all_stops_total`, `..._black`, ... |
| `computed--rates--arrest-rate` | `computed_rates_arrest_rate_asian`, `..._white`, ... |
| `disparity-index-by-race--disparity-index--all-stops` | `disparity_index_by_race_disparity_index_all_stops_white`, ... |

## Source

Pivots `combine_all_reports` (raw canonical metrics). NOT `reports_with_rank_percentile` — rank/percentile rows carry derived race-column values and would muddy the wide table. Adding a rank/percentile-aware wide bundle is a future, separate task if a consumer asks.

## Verification

- Materialized end-to-end in ~85s on WSL low-mem (pure pandas pivot + IO).
- All 26 bundles upload to S3; manifest re-materialized to include them.
- Spot-checked MSHP 2024 `rates-by-race--totals--all-stops` against tidy parquet — every race value matches.
- CSV opens cleanly with apostrophes/commas in agency names properly quoted.