### PR TITLE
Inject 'Missouri (all agencies)' rows into analytical parquets

### DIFF
--- a/missouri_vsr/assets/processed.py
+++ b/missouri_vsr/assets/processed.py
@@ -184,6 +184,82 @@ def _compute_statewide_rates(grouped: pd.DataFrame, value_cols: List[str]) -> pd
     return pd.DataFrame(derived_rows)
 
 
+def _build_statewide_canonical_rows(canonical: pd.DataFrame) -> pd.DataFrame:
+    """Build statewide-aggregate rows ('Missouri (all agencies)') matching the canonical schema.
+
+    Rolls up counts across all real agencies per (year, row_key), re-derives rate
+    rows via STATEWIDE_RATE_SPECS, and returns a frame whose columns are a strict
+    superset-compatible reindex of ``canonical.columns``. Skips population-normalized
+    rates — naive aggregation of ACS denominators is misleading because traffic
+    through a place is not who lives there.
+    """
+    if canonical.empty:
+        return pd.DataFrame(columns=canonical.columns)
+
+    value_cols = [c for c in PIVOT_VALUE_COLUMNS if c in canonical.columns]
+    if not value_cols:
+        return pd.DataFrame(columns=canonical.columns)
+
+    base = canonical[canonical["agency"] != STATEWIDE_AGENCY_NAME].copy()
+    derived_mask = base["row_key"].astype(str).str.contains(
+        r"-(?:rank|percentile|percentage)$", regex=True, na=False
+    )
+    base = base[~derived_mask]
+
+    # Exclude rate rows and population rows from aggregation source.
+    # Rates are re-derived from totals; population aggregation is misleading.
+    exclude_mask = (
+        base["row_key"].astype(str).str.endswith("-rate", na=False)
+        | base["row_key"].astype(str).str.startswith("rates-by-race--population", na=False)
+    )
+    count_base = base[~exclude_mask].copy()
+    for col in value_cols:
+        count_base[col] = pd.to_numeric(count_base[col], errors="coerce")
+
+    grouped = (
+        count_base.groupby(["year", "row_key"], dropna=True)[value_cols]
+        .sum(min_count=1)
+        .reset_index()
+    )
+    if grouped.empty:
+        return pd.DataFrame(columns=canonical.columns)
+
+    derived_rates = _compute_statewide_rates(grouped, value_cols)
+    all_rows = (
+        pd.concat([grouped, derived_rates], ignore_index=True)
+        if not derived_rates.empty
+        else grouped
+    )
+
+    meta_cols = ["table", "table_id", "section", "section_id", "metric", "metric_id"]
+    present_meta = [c for c in meta_cols if c in canonical.columns]
+    if present_meta:
+        meta_lookup = (
+            base[["row_key", *present_meta]]
+            .drop_duplicates("row_key", keep="first")
+            .set_index("row_key")
+        )
+        for col in present_meta:
+            all_rows[col] = all_rows["row_key"].map(meta_lookup[col])
+
+    all_rows["agency"] = STATEWIDE_AGENCY_NAME
+    if "canonical_key" in canonical.columns:
+        all_rows["canonical_key"] = all_rows["row_key"]
+    if "year" in all_rows.columns:
+        year_strs = all_rows["year"].apply(
+            lambda y: str(int(y)) if pd.notna(y) else ""
+        )
+        all_rows["row_id"] = (
+            year_strs + f"-{STATEWIDE_AGENCY_SLUG}-" + all_rows["row_key"].astype(str)
+        )
+
+    for col in canonical.columns:
+        if col not in all_rows.columns:
+            all_rows[col] = pd.NA
+
+    return all_rows[canonical.columns]
+
+
 def _build_percentage_frame(
     base: pd.DataFrame,
     value_cols: List[str],
@@ -427,6 +503,7 @@ def add_rank_percentile_rows(context, combined: pd.DataFrame) -> pd.DataFrame:
 
     tmp_dir = Path(tempfile.mkdtemp(prefix="vsr_rank_"))
     try:
+        chunk_columns: list[str] | None = None
         for yr in years:
             base = combined[combined["year"] == yr].copy()
             if base.empty:
@@ -454,11 +531,34 @@ def add_rank_percentile_rows(context, combined: pd.DataFrame) -> pd.DataFrame:
             _add_ingroup_pcts_and_ratios(base, value_cols)
 
             chunk = _rebuild_row_ids(pd.concat([base, *derived], ignore_index=True))
+            if chunk_columns is None:
+                chunk_columns = list(chunk.columns)
             chunk_path = tmp_dir / f"chunk_{yr}.parquet"
             chunk.to_parquet(chunk_path, index=False, engine="pyarrow")
             total_base += len(base)
             total_out += len(chunk)
             context.log.debug("Wrote year %d chunk: %d rows", yr, len(chunk))
+
+        # Inject statewide base rows (no rank/percentile/percentage variants).
+        # Built from the canonical-collapsed real-agency frame so the rollup is
+        # consistent with canonical_combined.parquet.
+        if chunk_columns is not None:
+            template = pd.DataFrame(columns=chunk_columns)
+            statewide_source_cols = [c for c in template.columns if c in combined.columns]
+            statewide_source = combined[statewide_source_cols].copy()
+            for col in chunk_columns:
+                if col not in statewide_source.columns:
+                    statewide_source[col] = pd.NA
+            statewide_source = statewide_source[chunk_columns]
+            statewide_rows = _build_statewide_canonical_rows(statewide_source)
+            if not statewide_rows.empty:
+                statewide_path = tmp_dir / "chunk_statewide.parquet"
+                statewide_rows.to_parquet(statewide_path, index=False, engine="pyarrow")
+                total_out += len(statewide_rows)
+                context.log.info(
+                    "Appended %d statewide base rows to reports_with_rank_percentile",
+                    len(statewide_rows),
+                )
 
         out_dir = Path(context.resources.data_dir_processed.get_path())
         out_path = out_dir / "reports_with_rank_percentile.parquet"
@@ -2331,11 +2431,17 @@ def canonical_combined_parquet(context) -> str:
     con.execute(f"COPY (SELECT * FROM canonical_combined WHERE year >= {DIST_MIN_YEAR}) TO '{out_path}' (FORMAT PARQUET)")
     con.close()
 
+    df = pd.read_parquet(out_path)
+
+    statewide_rows = _build_statewide_canonical_rows(df)
+    if not statewide_rows.empty:
+        df = pd.concat([df, statewide_rows], ignore_index=True)
+        context.log.info("Appended %d statewide rows to canonical combined", len(statewide_rows))
+
     # Clip rate values to 100% for dist outputs (bad source data can produce >100% rates).
     # Downloads keep the raw computed values.
     race_cols = [c for c in PIVOT_VALUE_COLUMNS if c != "Total"]
     all_val_cols = ["Total"] + race_cols
-    df = pd.read_parquet(out_path)
     rate_mask = df["canonical_key"].str.endswith("-rate", na=False)
     for col in all_val_cols:
         if col in df.columns:

--- a/tests/test_ops_functional.py
+++ b/tests/test_ops_functional.py
@@ -54,12 +54,15 @@ def test_add_rank_percentile_rows_op(tmp_path):
     )
     augmented = processed.add_rank_percentile_rows(context, df)
 
-    assert len(augmented) == len(df) * 4
+    # Real-agency rows: base + percentage + rank + percentile = len(df) * 4.
+    # Plus one statewide aggregate base row appended by _build_statewide_canonical_rows.
+    real_agency_rows = augmented[augmented["agency"] != processed.STATEWIDE_AGENCY_NAME]
+    assert len(real_agency_rows) == len(df) * 4
 
     base_row_key = "rates-by-race--totals--all-stops"
     slug_suffixes = {
         row_key.replace(base_row_key, "")
-        for row_key in augmented["row_key"].unique()
+        for row_key in real_agency_rows["row_key"].unique()
         if row_key.startswith(base_row_key)
     }
     assert slug_suffixes == {"", "-percentage", "-rank", "-percentile"}
@@ -77,6 +80,13 @@ def test_add_rank_percentile_rows_op(tmp_path):
     assert base_row["rank_dense"] == 1
     assert base_row["rank_count"] == 3
     assert base_row["rank_method"] == "dense"
+
+    # Statewide aggregate row should be present, with no rank/percentile/percentage variants.
+    statewide = augmented[augmented["agency"] == processed.STATEWIDE_AGENCY_NAME]
+    assert len(statewide) == 1
+    statewide_row = statewide.iloc[0]
+    assert statewide_row["row_key"] == base_row_key
+    assert statewide_row["Total"] == 100 + 200 + 150
 
 
 def test_compute_statewide_baselines_op(tmp_path):

--- a/tests/test_statewide_canonical_rows.py
+++ b/tests/test_statewide_canonical_rows.py
@@ -1,0 +1,141 @@
+"""Tests for the statewide-aggregate row injection (issue #34)."""
+from __future__ import annotations
+
+import pandas as pd
+
+from missouri_vsr.assets.processed import (
+    STATEWIDE_AGENCY_NAME,
+    STATEWIDE_AGENCY_SLUG,
+    _build_statewide_canonical_rows,
+)
+
+
+def _canonical_frame() -> pd.DataFrame:
+    """Two agencies, two years, a mix of count rows + the rate rows that should be re-derived."""
+    cols = [
+        "agency", "year",
+        "table_id", "table", "section_id", "section", "metric_id", "metric",
+        "row_id", "row_key", "canonical_key",
+        "Total", "White", "Black", "Hispanic", "Native American", "Asian", "Other",
+    ]
+    rows = [
+        # Stops: agency A 2023
+        ["Agency A", 2023, "ki", "Key Indicators", None, None, "stops", "Stops",
+         "2023-agency-a-stops", "stops", "stops",
+         100.0, 60.0, 30.0, 5.0, 2.0, 2.0, 1.0],
+        # Stops: agency B 2023
+        ["Agency B", 2023, "ki", "Key Indicators", None, None, "stops", "Stops",
+         "2023-agency-b-stops", "stops", "stops",
+         200.0, 150.0, 30.0, 10.0, 5.0, 3.0, 2.0],
+        # Searches: agency A 2023
+        ["Agency A", 2023, "ki", "Key Indicators", None, None, "searches", "Searches",
+         "2023-agency-a-searches", "searches", "searches",
+         10.0, 5.0, 4.0, 1.0, 0.0, 0.0, 0.0],
+        # Searches: agency B 2023
+        ["Agency B", 2023, "ki", "Key Indicators", None, None, "searches", "Searches",
+         "2023-agency-b-searches", "searches", "searches",
+         20.0, 10.0, 6.0, 2.0, 1.0, 1.0, 0.0],
+        # Pre-existing rate row — should be dropped from aggregation source, re-derived from totals
+        ["Agency A", 2023, "ki", "Key Indicators", None, None, "search-rate", "Search rate",
+         "2023-agency-a-search-rate", "search-rate", "search-rate",
+         0.10, 0.083, 0.133, 0.20, 0.0, 0.0, 0.0],
+        # Derived row that should be skipped wholesale
+        ["Agency A", 2023, "ki", "Key Indicators", None, None, "stops", "Stops",
+         "2023-agency-a-stops-rank", "stops-rank", "stops",
+         1, 1, 1, 1, 1, 1, 1],
+        # Population row — should be excluded from both aggregation and rate re-derivation
+        ["Agency A", 2023, "rbr", "Rates by Race", "pop", "Population", "pop", "Population",
+         "2023-agency-a-rates-by-race--population-totals--pop", "rates-by-race--population-totals--pop", "rates-by-race--population-totals--pop",
+         50000.0, 30000.0, 15000.0, 3000.0, 500.0, 1000.0, 500.0],
+    ]
+    return pd.DataFrame(rows, columns=cols)
+
+
+def test_aggregates_counts_and_derives_rates():
+    df = _canonical_frame()
+    statewide = _build_statewide_canonical_rows(df)
+
+    assert not statewide.empty
+    assert (statewide["agency"] == STATEWIDE_AGENCY_NAME).all()
+    assert set(statewide.columns) == set(df.columns)
+
+    stops_row = statewide[(statewide["row_key"] == "stops") & (statewide["year"] == 2023)].iloc[0]
+    assert stops_row["Total"] == 300.0
+    assert stops_row["White"] == 210.0
+
+    searches_row = statewide[(statewide["row_key"] == "searches") & (statewide["year"] == 2023)].iloc[0]
+    assert searches_row["Total"] == 30.0
+
+    search_rate = statewide[(statewide["row_key"] == "search-rate") & (statewide["year"] == 2023)]
+    assert len(search_rate) == 1
+    rate_row = search_rate.iloc[0]
+    assert rate_row["Total"] == pytest_approx(30.0 / 300.0)
+    assert rate_row["White"] == pytest_approx(15.0 / 210.0)
+
+
+def test_excludes_population_rows_from_aggregation():
+    df = _canonical_frame()
+    statewide = _build_statewide_canonical_rows(df)
+
+    pop_rows = statewide[statewide["row_key"].str.startswith("rates-by-race--population", na=False)]
+    assert pop_rows.empty, "population rows must not be in statewide aggregate"
+
+
+def test_skips_pre_existing_derived_rows():
+    df = _canonical_frame()
+    statewide = _build_statewide_canonical_rows(df)
+
+    derived = statewide[
+        statewide["row_key"].astype(str).str.contains(r"-(?:rank|percentile|percentage)$", regex=True)
+    ]
+    assert derived.empty
+
+
+def test_metadata_columns_populated():
+    df = _canonical_frame()
+    statewide = _build_statewide_canonical_rows(df)
+
+    stops_row = statewide[statewide["row_key"] == "stops"].iloc[0]
+    assert stops_row["table"] == "Key Indicators"
+    assert stops_row["metric"] == "Stops"
+
+
+def test_row_id_uses_statewide_slug():
+    df = _canonical_frame()
+    statewide = _build_statewide_canonical_rows(df)
+
+    for _, row in statewide.iterrows():
+        assert STATEWIDE_AGENCY_SLUG in str(row["row_id"])
+        assert str(row["row_id"]).startswith(f"{int(row['year'])}-{STATEWIDE_AGENCY_SLUG}-")
+
+
+def test_canonical_key_equals_row_key():
+    df = _canonical_frame()
+    statewide = _build_statewide_canonical_rows(df)
+
+    assert (statewide["canonical_key"] == statewide["row_key"]).all()
+
+
+def test_empty_input_returns_empty():
+    df = _canonical_frame().iloc[0:0]
+    statewide = _build_statewide_canonical_rows(df)
+    assert statewide.empty
+    assert list(statewide.columns) == list(df.columns)
+
+
+def test_re_running_on_augmented_frame_is_idempotent():
+    """If callers accidentally pass a frame that already has statewide rows, those are dropped first."""
+    df = _canonical_frame()
+    first = _build_statewide_canonical_rows(df)
+    combined = pd.concat([df, first], ignore_index=True)
+    second = _build_statewide_canonical_rows(combined)
+    pd.testing.assert_frame_equal(
+        first.reset_index(drop=True).sort_values(["year", "row_key"]).reset_index(drop=True),
+        second.reset_index(drop=True).sort_values(["year", "row_key"]).reset_index(drop=True),
+    )
+
+
+# tiny helper to avoid pytest.approx import boilerplate
+def pytest_approx(expected, rel=1e-6):
+    import pytest
+    return pytest.approx(expected, rel=rel)


### PR DESCRIPTION
Closes #34.

## What

Adds the synthetic statewide aggregate row to `canonical_combined.parquet` and `reports_with_rank_percentile.parquet` so a DuckDB-querying consumer (notably the planned MCP server) can `GROUP BY agency` and see Missouri statewide as just another row.

## How

- New `_build_statewide_canonical_rows(canonical)` helper rolls up counts per `(year, row_key)`, re-derives rate rows via the existing `STATEWIDE_RATE_SPECS` / `_compute_statewide_rates`, and excludes population-normalized rates (naive aggregation of ACS denominators is misleading).
- `canonical_combined_parquet`: appends statewide rows before the rate-clipping step.
- `add_rank_percentile_rows`: appends statewide base rows after the per-year rank/percentile loop. Statewide rows get NO `-rank` / `-percentile` / `-percentage` variants and `rank_dense` stays null, so real-agency ranking is untouched.

## Verification

Materialized both assets locally:

| Parquet | Statewide rows | Distinct row_keys |
|---|---|---|
| `canonical_combined.parquet` | 1,448 | 137 |
| `reports_with_rank_percentile.parquet` | 1,481 | 137 |

Spot-checks:
- Statewide `stops Total` for 2023 = 1,367,150 — matches `SUM(Total)` across real agencies for the same row_key.
- Statewide `search-rate` is derived from statewide totals (4.5% for 2023), not a mean of agency rates.
- `rank_dense` is null on all statewide rows; real-agency `rank_count` for 2023 stops = 508 (unchanged from pre-injection).
- No `-rank` / `-percentile` / `-percentage` variants exist for statewide rows.

## Test plan

- [x] 8 unit tests on the helper (totals, rate re-derivation, population exclusion, derived-row skip, metadata, row_id slug, idempotency on already-augmented input)
- [x] Functional test (`test_add_rank_percentile_rows_op`) updated to verify statewide row presence + absence of derived variants
- [x] Full suite: 49 passed, 5 skipped
- [x] End-to-end materialization against real data: 1,448 / 1,481 statewide rows produced, no ranking pollution
- [ ] Re-publish `releases/v2.1/` (downstream `agency_index_json` / `downloads_*`) — separate step once this is reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)