### PR TITLE
Self-source disparity denominator from ACS 5-year PUMS (full 10-yr window)

### DIFF
--- a/missouri_vsr/asset_checks/asset_checks.py
+++ b/missouri_vsr/asset_checks/asset_checks.py
@@ -437,3 +437,185 @@ asset_checks.extend(
 from missouri_vsr.assets.program_287g import check_all_mo_agencies_resolved
 
 asset_checks.append(check_all_mo_agencies_resolved)
+
+
+# ------------------------------------------------------------------------------
+# State statewide-report (parsed PDF) checks — tolerant of years/tables that the
+# AG never published or that the parser cannot read (skip, don't fail).
+# ------------------------------------------------------------------------------
+_STATE_REPORTS_PARQUET = Path("data/processed/state_reports_combined.parquet")
+_ACS_POP_PARQUET = Path("data/processed/acs_population_16plus.parquet")
+_AG_RACES = ["White", "Black", "Hispanic", "Native American", "Asian", "Other"]
+
+# (vintage, category) pairs where the AG's PUBLISHED denominator is itself an outlier,
+# so a >tolerance gap is expected and must not fail the build. The AG's 2021 ACS White
+# figure (2022 statewide report) is 4.02M / 81.84% — anomalously high vs both 2020
+# (3.95M) and 2022 (3.93M); our PUMS 5-year tabulation (~3.93M / 79.7%) sits naturally
+# between them and is internally consistent. Almost certainly an artifact of the
+# pandemic-disrupted 2021 ACS vintage. Documented, not silently widened.
+_KNOWN_AG_DENOMINATOR_ANOMALIES = {(2021, "White")}
+
+
+@asset_check(asset=AssetKey("state_reports_combined"))
+def check_state_reports_parsed_nonempty(state_reports_combined: pd.DataFrame) -> AssetCheckResult:
+    """Each report_year that parsed should yield a substantive table, not a near-empty
+    frame (a silent parser break). Only inspects years that ARE present — a year the AG
+    never published in tabular form simply won't appear and is not failed here."""
+    if state_reports_combined.empty or "report_year" not in state_reports_combined.columns:
+        return AssetCheckResult(passed=True, metadata={"skipped": True, "reason": "no state reports parsed"})
+    counts = state_reports_combined.groupby("report_year").size()
+    thin = {int(y): int(n) for y, n in counts.items() if n < 30}
+    return AssetCheckResult(
+        passed=not thin,
+        metadata={"report_years": [int(y) for y in counts.index],
+                  "rows_per_year": {int(y): int(n) for y, n in counts.items()},
+                  "suspiciously_thin": MetadataValue.json(thin)},
+    )
+
+
+@asset_check(asset=AssetKey("state_reports_combined"))
+def check_state_reports_population_shares_sane(state_reports_combined: pd.DataFrame) -> AssetCheckResult:
+    """Where a population-percentage row exists, the race shares should be valid
+    percentages that sum to ~100 plus the AG's non-White-Hispanic double-count
+    (observed ~102-104). Catches a misparsed/transposed population row. Skips if
+    no population-% rows are present."""
+    df = state_reports_combined
+    if df.empty or "metric" not in df.columns:
+        return AssetCheckResult(passed=True, metadata={"skipped": True, "reason": "no rows"})
+    metric = df["metric"].astype(str)
+    is_pct = metric.str.contains("%", na=False)
+    is_pop = (metric.str.contains("ACS pop", case=False, na=False)
+              | metric.str.contains(r"\bpopulation\b", case=False, regex=True, na=False))
+    is_dec = metric.str.contains("decennial", case=False, na=False)
+    pop = df[is_pct & is_pop & ~is_dec]
+    if pop.empty:
+        return AssetCheckResult(passed=True, metadata={"skipped": True, "reason": "no population-% rows"})
+    races = [c for c in _AG_RACES if c in df.columns]
+    violations = []
+    for _, row in pop.iterrows():
+        shares = [row.get(c) for c in races]
+        nums = [float(s) for s in shares if pd.notna(s)]
+        out_of_range = [c for c, s in zip(races, shares) if pd.notna(s) and not (0 <= float(s) <= 100)]
+        total = sum(nums)
+        if out_of_range or not (99 <= total <= 112):
+            violations.append({"report_year": int(row.get("report_year")), "metric": str(row.get("metric")),
+                               "share_sum": round(total, 2), "out_of_range": out_of_range})
+    return AssetCheckResult(
+        passed=not violations,
+        metadata={"population_rows_checked": len(pop),
+                  "violations": MetadataValue.json(violations[:25])},
+    )
+
+
+@asset_check(asset=AssetKey("state_reports_combined"))
+def check_state_reports_disparity_timeseries_sane(state_reports_combined: pd.DataFrame) -> AssetCheckResult:
+    """Where a disparity-index time series exists, values are plausible (0 <= d < 20)
+    and series_year falls within 2000..report_year. Skips reports without the series
+    (some years omit the disparity tables entirely)."""
+    df = state_reports_combined
+    if df.empty or "section" not in df.columns:
+        return AssetCheckResult(passed=True, metadata={"skipped": True, "reason": "no rows"})
+    ts = df[df["section"] == "disparity-index-timeseries"]
+    if ts.empty:
+        return AssetCheckResult(passed=True, metadata={"skipped": True, "reason": "no disparity time series present"})
+    races = [c for c in _AG_RACES if c in df.columns]
+    vals = ts[races].apply(pd.to_numeric, errors="coerce")
+    bad_value = int(((vals < 0) | (vals >= 20)).sum().sum())
+    sy = pd.to_numeric(ts.get("series_year"), errors="coerce")
+    ry = pd.to_numeric(ts.get("report_year"), errors="coerce")
+    bad_year = int(((sy < 2000) | (sy > ry)).sum())
+    return AssetCheckResult(
+        passed=bad_value == 0 and bad_year == 0,
+        metadata={"timeseries_rows": len(ts), "out_of_range_values": bad_value,
+                  "out_of_range_series_years": bad_year},
+    )
+
+
+# ------------------------------------------------------------------------------
+# ACS PUMS population checks
+# ------------------------------------------------------------------------------
+@asset_check(asset=AssetKey("acs_population_16plus"))
+def check_acs_population_sane(acs_population_16plus: pd.DataFrame) -> AssetCheckResult:
+    """Schema + range sanity: a Total 16+ in a plausible Missouri band, race shares in
+    (0, 100], and a share-sum above 100 (confirming the intended non-White-Hispanic
+    double-count is present, not silently dropped)."""
+    df = acs_population_16plus
+    if df.empty:
+        return AssetCheckResult(passed=False, metadata={"reason": "no ACS vintages materialized"})
+    pct_cols = [f"{r} pct" for r in _AG_RACES]
+    missing = [c for c in ["acs_vintage", "stops_year", "Total", *_AG_RACES, *pct_cols] if c not in df.columns]
+    if missing:
+        return AssetCheckResult(passed=False, metadata={"missing_columns": missing})
+    bad = []
+    for _, row in df.iterrows():
+        v = int(row["acs_vintage"])
+        total = row["Total"]
+        if not (4_000_000 <= total <= 6_000_000):
+            bad.append({"vintage": v, "issue": "Total out of MO band", "Total": int(total)})
+        shares = [row[c] for c in pct_cols]
+        if any(pd.isna(s) or not (0 < float(s) <= 100) for s in shares):
+            bad.append({"vintage": v, "issue": "race pct out of (0,100]"})
+        elif sum(float(s) for s in shares) <= 100:
+            bad.append({"vintage": v, "issue": "share-sum <= 100 (double-count missing?)",
+                        "sum": round(sum(float(s) for s in shares), 2)})
+    return AssetCheckResult(
+        passed=not bad,
+        metadata={"vintages": [int(v) for v in df["acs_vintage"]],
+                  "violations": MetadataValue.json(bad[:25])},
+    )
+
+
+@asset_check(asset=AssetKey("acs_population_16plus"))
+def check_acs_population_matches_ag_published(acs_population_16plus: pd.DataFrame) -> AssetCheckResult:
+    """Cross-check our PUMS tabulation against the AG's published 'NNNN ACS pop.' /
+    'NNNN population' COUNT rows in the statewide reports, for overlapping vintages.
+    Asserts White/Black/Hispanic/Total within 2% (the tiny Native American/Other buckets
+    are definitionally looser and excluded). Skips if the state reports aren't present or
+    don't overlap — this guards against a future ACS recode or vintage-mapping slip."""
+    df = acs_population_16plus
+    if df.empty or not _STATE_REPORTS_PARQUET.exists():
+        return AssetCheckResult(passed=True, metadata={"skipped": True,
+                                "reason": "acs empty or state_reports_combined.parquet absent"})
+    sr = pd.read_parquet(_STATE_REPORTS_PARQUET)
+    metric = sr["metric"].astype(str)
+    # COUNT rows only: "<year> ACS pop." or "<year> population" (no %, not Decennial).
+    is_count = (metric.str.match(r"^\d{4}\s+(ACS pop\.|population)$", case=False)
+                & ~metric.str.contains("%", na=False))
+    ag = sr[is_count].copy()
+    if ag.empty:
+        return AssetCheckResult(passed=True, metadata={"skipped": True, "reason": "no AG count rows to compare"})
+    ag["vintage"] = metric[is_count].str.extract(r"^(\d{4})").astype(int).values
+    by_vintage = {int(v): row for v, row in df.set_index("acs_vintage").iterrows()}
+    checked, violations, known_anomalies = [], [], []
+    for _, agrow in ag.drop_duplicates("vintage").iterrows():
+        v = int(agrow["vintage"])
+        ours = by_vintage.get(v)
+        if ours is None:
+            continue
+        checked.append(v)
+        for cat in ["Total", "White", "Black", "Hispanic"]:
+            a, o = agrow.get(cat), ours.get(cat)
+            if pd.isna(a) or pd.isna(o) or not a:
+                continue
+            rel = abs(float(o) - float(a)) / float(a)
+            if rel > 0.02:
+                entry = {"vintage": v, "category": cat, "ours": int(o),
+                         "ag_published": int(a), "rel_diff_pct": round(100 * rel, 2)}
+                (known_anomalies if (v, cat) in _KNOWN_AG_DENOMINATOR_ANOMALIES else violations).append(entry)
+    if not checked:
+        return AssetCheckResult(passed=True, metadata={"skipped": True, "reason": "no overlapping vintages"})
+    return AssetCheckResult(
+        passed=not violations,
+        metadata={"vintages_cross_checked": checked,
+                  "violations": MetadataValue.json(violations[:25]),
+                  "known_ag_anomalies": MetadataValue.json(known_anomalies)},
+    )
+
+
+asset_checks.extend([
+    check_state_reports_parsed_nonempty,
+    check_state_reports_population_shares_sane,
+    check_state_reports_disparity_timeseries_sane,
+    check_acs_population_sane,
+    check_acs_population_matches_ag_published,
+])

--- a/missouri_vsr/assets/acs_population.py
+++ b/missouri_vsr/assets/acs_population.py
@@ -1,0 +1,163 @@
+"""ACS 16+ population by race for Missouri, self-sourced from ACS 5-year PUMS.
+
+The disparity-index denominator is the ACS 5-year "ages 16+ by race" population.
+Standard ACS published tables cannot express a clean 16+ cut by race (the race-
+iterated age tables bucket ages as ``...15-17, 18-19...``), so the AG produces it
+from a custom tabulation. We reproduce the same definition directly from ACS 5-year
+PUMS microdata (filter ``AGEP >= 16``, weight by ``PWGTP``), which lets the
+population denominator extend across the full chart window instead of dying at the
+last year the AG published a parseable statewide report (2021). See
+``state_report.py`` for that format boundary.
+
+We pull PUMS from the Census Data API (``api.census.gov``) rather than the bulk
+``www2.census.gov`` zip files: the API serves the identical microdata (verified
+to the person against the bulk file for 2023) but reliably, where the bulk CDN
+intermittently times out (HTTP 520/524) on the older vintages. Needs CENSUS_API_KEY.
+
+Validated against the AG's published "2023 ACS pop." (2024 statewide report):
+Total/White/Black/Hispanic reproduce within <1%; the only loose categories are the
+tiny Native American and Other buckets (~7% of population combined), where RAC1P
+two-or-more / AIAN-combination assignment is a definitional judgment call.
+
+Category construction (matches the AG, incl. their documented non-White-Hispanic
+double-count — every category except White is race-alone *including* Hispanics):
+  - White:           RAC1P == 1 and HISP == 1   (White alone, not Hispanic)
+  - Black:           RAC1P == 2
+  - Native American: RAC1P in {3, 4, 5}         (AIAN alone / Alaska Native / AIAN combos)
+  - Asian:           RAC1P == 6
+  - Other:           RAC1P in {7, 8, 9}         (NHPI / Some other race / Two+ races)
+  - Hispanic:        HISP != 1                  (Hispanic of any race)
+  - Total:           everyone 16+
+
+Vintage mapping: stops year Y uses the ACS 5-year vintage ending Y-1 (the AG's
+2024 report uses "2023 ACS pop.", the 2025 report "2024 ACS pop.", etc.).
+"""
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+from typing import Dict, List, Optional
+
+import pandas as pd
+import requests
+
+from dagster import asset
+
+# ACS 5-year PUMS person records for Missouri (state 29) via the Census Data API.
+PUMS_API = "https://api.census.gov/data/{vintage}/acs/acs5/pums"
+
+# 5-year vintages (end year) to ingest. stops_year = vintage + 1, so 2015..2024
+# covers the 2016..2025 chart window. 5-year PUMS exists back to 2009 if the window
+# is ever widened.
+ACS_PUMS_VINTAGES: List[int] = list(range(2015, 2025))
+
+RACES = ["White", "Black", "Hispanic", "Native American", "Asian", "Other"]
+RACE_COLS = ["Total"] + RACES
+_PUMS_VARS = ["PWGTP", "AGEP", "RAC1P", "HISP"]
+
+
+def _aggregate_16plus_by_race(df: pd.DataFrame) -> Dict[str, int]:
+    """PWGTP-weighted 16+ population by race from a MO PUMS person frame."""
+    a = df[df["AGEP"] >= 16]
+    w = a["PWGTP"]
+
+    def wsum(mask) -> int:
+        return int(w[mask].sum())
+
+    return {
+        "Total": int(w.sum()),
+        "White": wsum((a["RAC1P"] == 1) & (a["HISP"] == 1)),
+        "Black": wsum(a["RAC1P"] == 2),
+        "Hispanic": wsum(a["HISP"] != 1),
+        "Native American": wsum(a["RAC1P"].isin([3, 4, 5])),
+        "Asian": wsum(a["RAC1P"] == 6),
+        "Other": wsum(a["RAC1P"].isin([7, 8, 9])),
+    }
+
+
+def _fetch_vintage_rows(context, vintage: int, key: str, cache_dir: Path, attempts: int = 5) -> Optional[list]:
+    """Fetch raw PUMS rows for one vintage from the Census API, with caching + retries.
+
+    Cached as JSON per vintage so re-runs don't re-hit the API. Retries on 5xx /
+    connection / malformed-JSON errors; returns None (skip vintage) on persistent
+    failure or a 4xx (e.g. a vintage the API doesn't serve)."""
+    cache = cache_dir / f"acs5_pums_mo_{vintage}.json"
+    if cache.exists():
+        context.log.debug("Using cached %s", cache)
+        return json.loads(cache.read_text())
+
+    url = PUMS_API.format(vintage=vintage)
+    params = {"get": ",".join(_PUMS_VARS), "for": "state:29", "key": key}
+    for attempt in range(1, attempts + 1):
+        try:
+            resp = requests.get(url, params=params, timeout=(10, 300))
+            if resp.status_code != 200:
+                context.log.warning("ACS5 PUMS %s -> HTTP %s (attempt %d/%d)",
+                                    vintage, resp.status_code, attempt, attempts)
+                if resp.status_code < 500:
+                    return None
+                time.sleep(3 * attempt)
+                continue
+            rows = resp.json()  # raises ValueError on a non-JSON error page
+            cache.write_text(json.dumps(rows))
+            return rows
+        except (requests.exceptions.RequestException, ValueError) as exc:
+            context.log.warning("ACS5 PUMS %s: %s (attempt %d/%d)", vintage, exc, attempt, attempts)
+            time.sleep(3 * attempt)
+    return None
+
+
+def _load_vintage(context, vintage: int, key: str, cache_dir: Path) -> Optional[Dict[str, int]]:
+    """Fetch (cached) and aggregate one ACS 5-year PUMS vintage for Missouri."""
+    rows = _fetch_vintage_rows(context, vintage, key, cache_dir)
+    if not rows or len(rows) < 2:
+        context.log.warning("ACS5 PUMS %s unavailable after retries; skipping", vintage)
+        return None
+    df = pd.DataFrame(rows[1:], columns=rows[0])
+    for c in _PUMS_VARS:
+        df[c] = pd.to_numeric(df[c], errors="coerce")
+    counts = _aggregate_16plus_by_race(df)
+    context.log.info("ACS5 PUMS %s: %d MO person rows -> Total 16+ = %d", vintage, len(df), counts["Total"])
+    return counts
+
+
+@asset(
+    group_name="acs_population",
+    required_resource_keys={"data_dir_source", "data_dir_processed"},
+    description="ACS 5-year PUMS 16+ population by race for Missouri, per vintage, via the "
+                "Census API. Self-sourced disparity denominator; stops_year = vintage + 1.",
+)
+def acs_population_16plus(context) -> pd.DataFrame:
+    key = os.getenv("CENSUS_API_KEY")
+    if not key:
+        raise ValueError("CENSUS_API_KEY is not set; required to query the Census PUMS API.")
+
+    cache_dir = Path(context.resources.data_dir_source.get_path()) / "pums"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+
+    records: List[dict] = []
+    for vintage in ACS_PUMS_VINTAGES:
+        counts = _load_vintage(context, vintage, key, cache_dir)
+        if counts is None:
+            continue
+        total = counts["Total"] or 0
+        rec = {"acs_vintage": vintage, "stops_year": vintage + 1}
+        for c in RACE_COLS:
+            rec[c] = counts[c]
+        for r in RACES:
+            rec[f"{r} pct"] = round(100 * counts[r] / total, 4) if total else None
+        records.append(rec)
+
+    df = pd.DataFrame.from_records(records)
+    out_dir = Path(context.resources.data_dir_processed.get_path())
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / "acs_population_16plus.parquet"
+    df.to_parquet(out_path, index=False)
+    context.add_output_metadata({
+        "rows": len(df),
+        "vintages": sorted(df["acs_vintage"].tolist()) if not df.empty else [],
+        "path": str(out_path),
+    })
+    return df

--- a/missouri_vsr/assets/analysis/initial_impressions_2025.py
+++ b/missouri_vsr/assets/analysis/initial_impressions_2025.py
@@ -59,7 +59,11 @@ OFFICIAL_PC_LABEL = {
     "Other": "probable-cause--other",
 }
 
-_DEPS = [AssetKey("canonical_combined_parquet"), AssetKey("state_reports_combined")]
+_DEPS = [
+    AssetKey("canonical_combined_parquet"),
+    AssetKey("state_reports_combined"),
+    AssetKey("acs_population_16plus"),
+]
 
 
 # ------------------------------------------------------------------------------
@@ -78,6 +82,22 @@ def _load_state_reports(context) -> pd.DataFrame:
     return pd.read_parquet(_processed(context, "state_reports_combined.parquet"))
 
 
+def _acs_pop_pct(context) -> Dict[int, Dict[str, float]]:
+    """stops_year -> {race: ACS 16+ population %}, self-sourced from ACS 5-year PUMS.
+
+    Replaces the state report as the disparity denominator: we tabulate ages 16+ by
+    race ourselves (acs_population_16plus), so the population line spans the full
+    chart window instead of stopping at the last parseable AG statewide report.
+    Keyed by stops_year (= acs_vintage + 1), matching the AG's vintage convention.
+    Reproduces the AG's published denominators within ~1% on the major categories.
+    """
+    acs = pd.read_parquet(_processed(context, "acs_population_16plus.parquet"))
+    out: Dict[int, Dict[str, float]] = {}
+    for _, row in acs.iterrows():
+        out[int(row["stops_year"])] = {r: _num(row.get(f"{r} pct")) for r in RACES}
+    return out
+
+
 def _num(v) -> Optional[float]:
     return None if v is None or pd.isna(v) else float(v)
 
@@ -89,30 +109,6 @@ def _race_values(df: pd.DataFrame, canonical_key: str, year: int) -> Optional[Di
         return None
     row = r.iloc[0]
     return {c: _num(row.get(c)) for c in RACE_COLS}
-
-
-def _official_acs_pop_pct(sr: pd.DataFrame) -> Dict[int, Dict[str, float]]:
-    """report_year -> {race: ACS 16+ population %}. Deduped across tables.
-
-    The denominator label drifts across report years: 2022+ reports use
-    ``<year> ACS pop. %`` (alongside a separate ``Decennial pop. %`` we must NOT
-    pick up), while the 2021 report labels the same ACS 16+ estimate plainly as
-    ``2020 population %`` (confirmed ACS 16+ five-year estimate in that report's
-    own notes). Match either form; exclude the Decennial row.
-    """
-    metric = sr["metric"].astype(str)
-    is_pct = metric.str.contains("%", na=False)
-    is_acs16 = (
-        metric.str.contains("ACS pop", case=False, na=False)
-        | metric.str.contains(r"\bpopulation\b", case=False, regex=True, na=False)
-    )
-    is_decennial = metric.str.contains("decennial", case=False, na=False)
-    pop = sr[is_pct & is_acs16 & ~is_decennial]
-    pop = pop.drop_duplicates(subset=["report_year"])
-    out: Dict[int, Dict[str, float]] = {}
-    for _, row in pop.iterrows():
-        out[int(row["report_year"])] = {c: _num(row.get(c)) for c in RACES}
-    return out
 
 
 def _official_all_stops_disparity(sr: pd.DataFrame) -> Dict[int, Dict[str, float]]:
@@ -168,16 +164,15 @@ def _write_outputs(context, name: str, payload: dict, rows: List[dict]) -> List[
 def ii2025_disparity_index(context) -> List[str]:
     sw = _load_statewide(context)
     sr = _load_state_reports(context)
-    pop_by_year = _official_acs_pop_pct(sr)          # year -> {race: pop %}
+    pop_by_year = _acs_pop_pct(context)              # stops_year -> {race: ACS 16+ pop %}
     official_disp = _official_all_stops_disparity(sr)  # series_year -> {race: disparity}
 
     metrics = {"stops": "stops", "searches": "searches", "arrests": "arrests"}
     # 10-year window ending at the primary year. Shares come from our statewide
-    # counts (available every year) and the official disparity line spans the full
-    # window from the latest report's 2000..N series; the independently-computed
-    # disparity is only populated for years where a statewide report gave us an ACS
-    # 16+ denominator (the AG's tabular statewide report format only goes back to
-    # 2021 — earlier years carry official_disparity_index but no computed value).
+    # counts (available every year); the disparity denominator is our own ACS
+    # 5-year PUMS 16+-by-race tabulation (acs_population_16plus), which spans the
+    # full window, so disparity_index is computed for every year. The AG's published
+    # disparity (2000..N series) rides alongside as official_disparity_index.
     years = list(range(PRIMARY_YEAR - 9, PRIMARY_YEAR + 1))
     denominator_years = sorted(y for y in pop_by_year if y in years)
 
@@ -186,14 +181,17 @@ def ii2025_disparity_index(context) -> List[str]:
         "metric": "disparity_index",
         "window": {"start": years[0], "end": years[-1], "n_years": len(years)},
         "definition": "(group's share of <metric>) / (group's share of 16+ ACS population)",
-        "population_basis": "ACS 5-year estimates, ages 16+, as reported in the statewide "
-                            "annual report for that year (matches the AG's disparity-index denominator)",
+        "population_basis": "ACS 5-year PUMS, ages 16+, by race, tabulated by us "
+                            "(acs_population_16plus; vintage = stops_year - 1, the AG's convention). "
+                            "Reproduces the AG's published 16+ denominators within ~1% on the major "
+                            "categories; lets the denominator span the full window where the AG's "
+                            "parseable statewide report does not.",
         "computed_disparity_years": denominator_years,
-        "computed_disparity_coverage": "disparity_index is computed only for years with an ingested "
-                                       "statewide-report ACS denominator; other years in the window carry "
-                                       "share_pct and official_disparity_index but disparity_index = null.",
-        "caveat": "ACS provides race-specific Hispanic estimates only for White, so non-White "
-                  "Hispanic residents are double-counted in the population shares (per the AG's note).",
+        "computed_disparity_coverage": "disparity_index is computed for every year with an ACS PUMS "
+                                       "denominator (the full window unless a PUMS vintage was unavailable). "
+                                       "official_disparity_index carries the AG's published series for comparison.",
+        "caveat": "Every race category except White is race-alone INCLUDING Hispanics (matching the AG), "
+                  "so non-White Hispanic residents are double-counted in the population shares.",
         "statewide_counts_source": "computed: 'Missouri (all agencies)' aggregate summed from per-agency reports",
         "official_comparison": "official_disparity_index = AG's published all-stops disparity (Table 3 time series)",
         "years": {},

--- a/missouri_vsr/assets/analysis/initial_impressions_2025.py
+++ b/missouri_vsr/assets/analysis/initial_impressions_2025.py
@@ -7,6 +7,8 @@ Deliverables (all statewide):
      all-other, plus a full per-reason breakdown, per year.
   3. ii2025_race_summary_2025    — total stops, search rate, contraband hit rate
      by race, statewide, 2025.
+  4. ii2025_outcome_test_by_year — the outcome test (search rate vs contraband
+     hit rate by race, each relative to white) for every year in the data.
 
 Statewide counts are *computed* by us (the "Missouri (all agencies)" aggregate in
 canonical_combined, summed from the per-agency reports). The 16+ population
@@ -398,6 +400,95 @@ def ii2025_race_summary_2025(context) -> List[str]:
         })
 
     return _write_outputs(context, "ii2025_race_summary_2025", payload, rows)
+
+
+# ------------------------------------------------------------------------------
+# 4. Outcome test, all years: search rate vs contraband hit rate by race
+# ------------------------------------------------------------------------------
+@asset(
+    name="ii2025_outcome_test_by_year",
+    group_name=GROUP,
+    deps=_DEPS,
+    required_resource_keys={"data_dir_processed", "data_dir_out"},
+    description="Outcome test (Knowles, Persico & Todd 2001) by race for every year: "
+                "search rate vs contraband hit rate, each relative to white, statewide, vs official.",
+)
+def ii2025_outcome_test_by_year(context) -> List[str]:
+    sw = _load_statewide(context)
+    sr = _load_state_reports(context)
+
+    # All years for which we have a statewide search rate (the broader metric);
+    # contraband hit rate — the crux of the outcome test — only exists 2020+, so
+    # earlier years carry a null hit rate and outcome_test_computable=False.
+    years = sorted(
+        int(y)
+        for y in sw[sw["canonical_key"] == "search-rate"]["year"].dropna().unique()
+    )
+
+    payload = {
+        "post": POST_SLUG,
+        "metric": "outcome_test_by_year",
+        "note": "The outcome test: a group searched MORE often than white drivers yet "
+                "yielding contraband LESS often is the bias signal. *_vs_white columns "
+                "are ratios to the white rate (1.00 = same as white). Contraband hit rate "
+                "is only reported statewide from 2020 on, so outcome_test_computable is "
+                "False for earlier years (search rate only).",
+        "definitions": {
+            "search_rate": "100 x searches / stops",
+            "contraband_hit_rate": "100 x searches-with-contraband / searches",
+            "search_rate_vs_white": "search_rate(race) / search_rate(white)",
+            "hit_rate_vs_white": "contraband_hit_rate(race) / contraband_hit_rate(white)",
+        },
+        "statewide_counts_source": "computed: 'Missouri (all agencies)' aggregate",
+        "by_year": {},
+    }
+    rows: List[dict] = []
+    for y in years:
+        search_rate = _race_values(sw, "search-rate", y) or {}
+        hit_rate = _race_values(sw, "contraband-hit-rate", y) or {}
+        off_search_rate = _official_metric(sr, y, "Rates", "Search rate") or {}
+        off_hit_rate = _official_metric(sr, y, "Rates", "Contraband hit rate") or {}
+
+        white_sr = search_rate.get("White")
+        white_hr = hit_rate.get("White")
+        computable = white_hr is not None
+
+        by_race: Dict[str, dict] = {}
+        for r in RACE_COLS:
+            sr_r = search_rate.get(r)
+            hr_r = hit_rate.get(r)
+            cell = {
+                "search_rate": sr_r,
+                "contraband_hit_rate": hr_r,
+                "search_rate_vs_white": round(sr_r / white_sr, 4) if (sr_r is not None and white_sr) else None,
+                "hit_rate_vs_white": round(hr_r / white_hr, 4) if (hr_r is not None and white_hr) else None,
+                "official": {
+                    "search_rate": off_search_rate.get(r),
+                    "contraband_hit_rate": off_hit_rate.get(r),
+                },
+                "delta_vs_official": {
+                    "search_rate": _delta(sr_r, off_search_rate.get(r)),
+                    "contraband_hit_rate": _delta(hr_r, off_hit_rate.get(r)),
+                },
+            }
+            by_race[r] = cell
+            rows.append({
+                "year": y, "race": r,
+                "search_rate": sr_r, "contraband_hit_rate": hr_r,
+                "search_rate_vs_white": cell["search_rate_vs_white"],
+                "hit_rate_vs_white": cell["hit_rate_vs_white"],
+                "outcome_test_computable": computable,
+                "official_search_rate": off_search_rate.get(r),
+                "official_contraband_hit_rate": off_hit_rate.get(r),
+                "delta_search_rate": cell["delta_vs_official"]["search_rate"],
+                "delta_contraband_hit_rate": cell["delta_vs_official"]["contraband_hit_rate"],
+            })
+        payload["by_year"][str(y)] = {
+            "outcome_test_computable": computable,
+            "by_race": by_race,
+        }
+
+    return _write_outputs(context, "ii2025_outcome_test_by_year", payload, rows)
 
 
 # ------------------------------------------------------------------------------

--- a/missouri_vsr/assets/analysis/initial_impressions_2025.py
+++ b/missouri_vsr/assets/analysis/initial_impressions_2025.py
@@ -398,3 +398,139 @@ def ii2025_race_summary_2025(context) -> List[str]:
         })
 
     return _write_outputs(context, "ii2025_race_summary_2025", payload, rows)
+
+
+# ------------------------------------------------------------------------------
+# 4. Agencies reporting: roster composition + the 2024 drop-out / 2025 return
+# ------------------------------------------------------------------------------
+@asset(
+    name="ii2025_agencies_reporting",
+    group_name=GROUP,
+    deps=[AssetKey("canonical_combined_parquet")],
+    required_resource_keys={"data_dir_processed", "data_dir_out"},
+    description="Per-year agency reporting composition (consistent / returning / new "
+                "nonzero reporters + zero-stop filers) over a 10-year window, plus the "
+                "cohort that dropped out in 2024 and returned in 2025. Shows that the "
+                "year-over-year swing in reported stops is largely reporting-roster churn.",
+)
+def ii2025_agencies_reporting(context) -> List[str]:
+    df = pd.read_parquet(_processed(context, "canonical_combined.parquet"))
+    df = df[df["agency"] != STATEWIDE_AGENCY]
+    st = df[df["canonical_key"] == "stops"][["agency", "year", "Total"]].copy()
+    st["Total"] = st["Total"].fillna(0)
+
+    # Nonzero reporters and summed stops, per year (clean canonical names).
+    nz: Dict[int, set] = {}
+    stops_sum: Dict[int, float] = {}
+    for y, g in st[st["Total"] > 0].groupby("year"):
+        nz[int(y)] = set(g["agency"])
+        stops_sum[int(y)] = float(g["Total"].sum())
+    all_years = sorted(nz)
+
+    window = list(range(PRIMARY_YEAR - 9, PRIMARY_YEAR + 1))  # 2016..2025
+    # Zero-stop filers are now first-class 'stops' rows with Total == 0 (folded in
+    # at the combine step, issue #41) — count them straight from canonical.
+    zero_by_year: Dict[int, set] = {
+        int(y): set(g["agency"]) for y, g in st[st["Total"] == 0].groupby("year")
+    }
+
+    def prior_filed(y: int) -> set:
+        s: set = set()
+        for yy in all_years:
+            if yy < y:
+                s |= nz[yy]
+        return s
+
+    by_year: Dict[str, dict] = {}
+    rows: List[dict] = []
+    for y in window:
+        cur = nz.get(y, set())
+        prev = nz.get(y - 1, set())
+        before = prior_filed(y)
+        consistent = cur & prev                # reported this year AND last year
+        returning = (cur - prev) & before      # reported before, gap last year
+        new = cur - before                     # never reported before
+        n_zero = len(zero_by_year.get(y, []))
+        cell = {
+            "reported_nonzero": len(cur),
+            "consistent": len(consistent),
+            "returning": len(returning),
+            "new": len(new),
+            "zero_stop_filers": n_zero,
+            "total_filed": len(cur) + n_zero,
+            "total_stops": round(stops_sum.get(y, 0.0)),
+        }
+        by_year[str(y)] = cell
+        rows.append({"year": y, **cell})
+
+    # 2024 churn detail: agencies that reported (nonzero) in 2023, vanished from
+    # the 2024 report entirely, and came back in 2025.
+    s23 = st[(st["year"] == 2023) & (st["Total"] > 0)].set_index("agency")["Total"]
+    s25 = st[(st["year"] == 2025) & (st["Total"] > 0)].set_index("agency")["Total"]
+    nz23, nz24, nz25 = nz.get(2023, set()), nz.get(2024, set()), nz.get(2025, set())
+    came_back = sorted((nz23 - nz24) & nz25, key=lambda a: -float(s25.get(a, 0)))
+    comeback_rows = [
+        {"agency": a, "stops_2023": int(s23.get(a, 0)),
+         "reported_2024": False, "stops_2025": int(s25.get(a, 0))}
+        for a in came_back
+    ]
+    raw23, raw24, raw25 = stops_sum.get(2023, 0.0), stops_sum.get(2024, 0.0), stops_sum.get(2025, 0.0)
+    panel = nz23 & nz24 & nz25
+    panel_23 = float(s23.reindex(panel).fillna(0).sum())
+    panel_25 = float(s25.reindex(panel).fillna(0).sum())
+    cb_25 = float(s25.reindex(came_back).fillna(0).sum()) if came_back else 0.0
+
+    payload = {
+        "post": POST_SLUG,
+        "metric": "agencies_reporting",
+        "window": {"start": window[0], "end": window[-1]},
+        "definitions": {
+            "reported_nonzero": "agencies with >0 stops in the per-agency tables (from canonical_combined)",
+            "consistent": "reported (nonzero) this year AND the prior year",
+            "returning": "reported this year, NOT the prior year, but had reported in some earlier year",
+            "new": "reported this year, never reported in any prior year on record",
+            "zero_stop_filers": "agencies that filed but recorded zero stops (a 'stops' row of 0). For 2020+ "
+                                "these come from the report's prose 'Zero Stops' list, now folded into "
+                                "canonical_combined at the combine step (issue #41); earlier years pick up any "
+                                "agency whose all-stops total is 0.",
+            "total_filed": "reported_nonzero + zero_stop_filers (every agency that filed anything)",
+        },
+        "note": "The number of agencies in the report swings year to year. 2024 is a sharp dip: about "
+                "80% of the agencies missing in 2024 reappear in 2025, bringing back nearly identical "
+                "stop volume — so most of the 2024->2025 rise in total stops is returning agencies, not "
+                "more policing. Compare absolute counts across these years with caution.",
+        "headline_2024": {
+            "reported_2023": len(nz23),
+            "reported_2024": len(nz24),
+            "reported_2025": len(nz25),
+            "dropped_from_2023_to_2024": len(nz23 - nz24),
+            "of_which_returned_in_2025": len(came_back),
+            "comeback_stops_2023": int(s23.reindex(came_back).fillna(0).sum()) if came_back else 0,
+            "comeback_stops_2025": int(cb_25),
+            "raw_stops_2024": round(raw24),
+            "raw_stops_2025": round(raw25),
+            "raw_change_2024_to_2025": round(raw25 - raw24),
+            "raw_pct_change_2024_to_2025": round((raw25 / raw24 - 1) * 100, 1) if raw24 else None,
+            "comeback_share_of_raw_increase_pct": round(cb_25 / (raw25 - raw24) * 100) if raw25 != raw24 else None,
+            "balanced_panel_agencies": len(panel),
+            "balanced_panel_stops_2023": round(panel_23),
+            "balanced_panel_stops_2025": round(panel_25),
+            "balanced_panel_pct_change_2023_to_2025": round((panel_25 / panel_23 - 1) * 100, 1) if panel_23 else None,
+        },
+        "by_year": by_year,
+        "comeback_2024_to_2025": comeback_rows,
+    }
+
+    out_dir = Path(context.resources.data_dir_out.get_path()) / "analysis" / POST_SLUG
+    out_dir.mkdir(parents=True, exist_ok=True)
+    json_path = out_dir / "ii2025_agencies_reporting.json"
+    csv_path = out_dir / "ii2025_agencies_reporting.csv"
+    comeback_path = out_dir / "ii2025_agencies_dropped_2024_returned_2025.csv"
+    json_path.write_text(json.dumps(payload, indent=2))
+    pd.DataFrame(rows).to_csv(csv_path, index=False)
+    pd.DataFrame(comeback_rows).to_csv(comeback_path, index=False)
+    context.add_output_metadata({
+        "json": str(json_path), "composition_csv": str(csv_path),
+        "comeback_csv": str(comeback_path), "comeback_agencies": len(comeback_rows),
+    })
+    return [str(json_path), str(csv_path), str(comeback_path)]

--- a/missouri_vsr/assets/analysis/initial_impressions_2025.py
+++ b/missouri_vsr/assets/analysis/initial_impressions_2025.py
@@ -434,6 +434,8 @@ def ii2025_outcome_test_by_year(context) -> List[str]:
                 "is only reported statewide from 2020 on, so outcome_test_computable is "
                 "False for earlier years (search rate only).",
         "definitions": {
+            "searches": "count of searches (the denominator behind the hit rate / "
+                        "numerator behind the search rate; small counts => noisy rates)",
             "search_rate": "100 x searches / stops",
             "contraband_hit_rate": "100 x searches-with-contraband / searches",
             "search_rate_vs_white": "search_rate(race) / search_rate(white)",
@@ -444,6 +446,7 @@ def ii2025_outcome_test_by_year(context) -> List[str]:
     }
     rows: List[dict] = []
     for y in years:
+        searches = _race_values(sw, "searches", y) or {}
         search_rate = _race_values(sw, "search-rate", y) or {}
         hit_rate = _race_values(sw, "contraband-hit-rate", y) or {}
         off_search_rate = _official_metric(sr, y, "Rates", "Search rate") or {}
@@ -458,6 +461,7 @@ def ii2025_outcome_test_by_year(context) -> List[str]:
             sr_r = search_rate.get(r)
             hr_r = hit_rate.get(r)
             cell = {
+                "searches": searches.get(r),
                 "search_rate": sr_r,
                 "contraband_hit_rate": hr_r,
                 "search_rate_vs_white": round(sr_r / white_sr, 4) if (sr_r is not None and white_sr) else None,
@@ -474,6 +478,7 @@ def ii2025_outcome_test_by_year(context) -> List[str]:
             by_race[r] = cell
             rows.append({
                 "year": y, "race": r,
+                "searches": searches.get(r),
                 "search_rate": sr_r, "contraband_hit_rate": hr_r,
                 "search_rate_vs_white": cell["search_rate_vs_white"],
                 "hit_rate_vs_white": cell["hit_rate_vs_white"],

--- a/missouri_vsr/assets/extract.py
+++ b/missouri_vsr/assets/extract.py
@@ -288,6 +288,66 @@ def _clean_agency_name(name: str) -> str:
     return text
 
 
+def parse_zero_stop_agencies(report_text: str) -> list[str]:
+    """Agency names from the prose "Zero Stops" section of a 2020+ per-agency
+    report — agencies that filed but recorded zero stops, so they never get a
+    per-agency table (and would otherwise be dropped entirely). Returns raw
+    report names (not crosswalked). Returns [] when the section is absent
+    (pre-2020 combined reports, or a year whose PDF doesn't carry it). See #41.
+    """
+    for m in re.finditer(r"Zero Stops", report_text):
+        seg = report_text[m.end(): m.end() + 2500]
+        body = re.split(r"\n\s*2?\s*Agency Results", seg)[0]
+        if re.search(r"\.\s*\.\s*\.\s*\.", body):  # table-of-contents hit (dotted leaders)
+            continue
+        if not re.search(r"Dept|Division|College|Police|Department", body):
+            continue
+        flat = re.sub(r"\s+", " ", body).strip()
+        names = [n.strip().rstrip(".").strip() for n in flat.split(",")]
+        return [n for n in names if len(n) > 3 and not n.isdigit()]
+    return []
+
+
+def zero_stop_rows(reports_dir: Path, year: int, *, existing: set[str] | None = None) -> list[dict]:
+    """Synthetic all-stops=0 extract records for each agency in `year`'s "Zero
+    Stops" list, so filed-but-reported-nothing agencies become first-class rows
+    (canonical_key 'stops', Total 0) instead of vanishing. `existing` is the set
+    of already-present cleaned agency names for the year, to avoid duplicating an
+    agency that does have a table. See issue #41.
+    """
+    layout = reports_dir / f"VSRreport{year}.layout.txt"
+    if not layout.exists():
+        return []
+    names = parse_zero_stop_agencies(layout.read_text(encoding="utf-8", errors="replace"))
+    if not names:
+        return []
+    table_title = "Rates by Race"
+    table_id = _slugify_simple(table_title)
+    section = "Totals"
+    section_id = _build_section_id(section)
+    metric = "All stops"
+    metric_id = _build_metric_id(metric)
+    row_key = _build_row_key(table_id, section_id, metric_id)
+    existing = existing or set()
+    rows: list[dict] = []
+    seen: set[str] = set()
+    for raw in names:
+        agency = _clean_agency_name(raw)
+        if not agency or agency in existing or agency in seen:
+            continue
+        seen.add(agency)
+        rows.append({
+            "Total": 0, "White": 0, "Black": 0, "Hispanic": 0,
+            "Native American": 0, "Asian": 0, "Other": 0,
+            "year": year, "row_key": row_key, "agency": agency,
+            "table": table_title, "table_id": table_id,
+            "section": section, "section_id": section_id,
+            "metric": metric, "metric_id": metric_id,
+            "row_id": _build_row_id(year, agency, table_id, section_id, metric_id),
+        })
+    return rows
+
+
 def _is_page_number(line: str) -> bool:
     stripped = line.strip()
     return stripped.isdigit()

--- a/missouri_vsr/assets/processed.py
+++ b/missouri_vsr/assets/processed.py
@@ -2645,6 +2645,28 @@ def homepage_stats_json(context, canonical_combined_parquet: str) -> str:
     return write_homepage_stats_json(context, pd.read_parquet(canonical_combined_parquet))
 
 
+# Ordered release notes; the manifest emits every entry up to the current version.
+_RELEASE_CHANGELOG = [
+    ("2.0", "v2.0: Added 2001–2019 pre-2020 format data with canonical_key normalization; "
+            "row_key in all dist outputs is now canonical_key (era-independent); agency JSON "
+            "partitioned by year (dist/agency_year/{slug}/{year}.json)."),
+    ("2.3", "v2.3: Folded in agencies that filed but reported zero stops — previously dropped "
+            "because the 2020+ reports list them in a prose 'Zero Stops' section rather than a "
+            "table. They now appear with a stops=0 row (issue #41)."),
+]
+
+
+def _version_tuple(v: str) -> tuple[int, ...]:
+    return tuple(int(p) for p in re.findall(r"\d+", v)) or (0,)
+
+
+def _release_version_from_prefix(default: str = "2.0") -> str:
+    """Parse the release version from MISSOURI_VSR_S3_PREFIX (releases/vX.Y)."""
+    prefix = os.getenv("MISSOURI_VSR_S3_PREFIX", "") or ""
+    m = re.search(r"v(\d+(?:\.\d+)?)", prefix)
+    return m.group(1) if m else default
+
+
 @asset(
     name="dist_manifest_json",
     group_name="dist",
@@ -2669,18 +2691,21 @@ def dist_manifest_json(context) -> str:
     years = [int(r[0]) for r in years_rows]
     canonical_metrics = [r[0] for r in canonical_rows if not _is_cross_rate_pairing(r[0])]
 
+    # Releases are cut by setting MISSOURI_VSR_S3_PREFIX=releases/vX.Y; derive the
+    # release version from it so the manifest self-labels instead of staying "2.0".
+    version = _release_version_from_prefix()
+    # Cumulative changelog: every note up to and including the current version.
+    changelog = " ".join(
+        note for ver, note in _RELEASE_CHANGELOG if _version_tuple(ver) <= _version_tuple(version)
+    )
+
     manifest = {
-        "version": "2.0",
+        "version": version,
         "released": date.today().isoformat(),
         "years": years,
         "schema_version": "2.0",
         "canonical_metrics": canonical_metrics,
-        "changelog": (
-            f"v2.0: Added {DIST_MIN_YEAR}–2019 pre-2020 format data with canonical_key normalization. "
-            "row_key in all dist outputs is now canonical_key (era-independent). "
-            "Agency JSON partitioned by year (dist/agency_year/{slug}/{year}.json). "
-            f"Years before {DIST_MIN_YEAR} excluded from dist outputs (sparse/unreliable coverage)."
-        ),
+        "changelog": changelog,
     }
 
     out_dir = Path(context.resources.data_dir_out.get_path())

--- a/missouri_vsr/assets/reports.py
+++ b/missouri_vsr/assets/reports.py
@@ -9,7 +9,13 @@ import requests
 
 from dagster import AssetIn, AssetKey, AssetOut, In, Out, Output, graph_asset, op, multi_asset
 
-from missouri_vsr.assets.extract import YEAR_URLS, _ensure_pdftotext, _slugify_simple
+from missouri_vsr.assets.extract import (
+    RACE_COLUMNS,
+    YEAR_URLS,
+    _ensure_pdftotext,
+    _slugify_simple,
+    zero_stop_rows,
+)
 from missouri_vsr.assets.s3_utils import upload_file_to_s3
 from missouri_vsr.cli.crosswalk import _normalize_name
 
@@ -415,6 +421,34 @@ def combine_reports(context, **extracted_reports: dict[str, pd.DataFrame]) -> pd
         combined = combined.rename(columns={"slug": "row_key"})
     if "slug" in combined.columns:
         combined = combined.drop(columns=["slug"])
+
+    # Fold in agencies that filed but reported zero stops. The 2020+ reports list
+    # these in a prose "Zero Stops" section we never parse into tables, so without
+    # this they vanish from the dataset entirely. Emit one all-stops=0 row each
+    # (raw row_key 'rates-by-race--totals--all-stops'); they then flow through name
+    # normalization and canonical_key mapping (-> 'stops') like any other row, and
+    # count as having reported. See issue #41.
+    reports_dir = Path("data/src/reports")
+    if "year" in combined.columns and "agency" in combined.columns:
+        present_by_year: dict[int, set[str]] = {
+            int(y): set(g["agency"].dropna().astype(str))
+            for y, g in combined.groupby("year")
+        }
+        zero_records: list[dict] = []
+        for y in sorted({int(v) for v in combined["year"].dropna().unique()}):
+            zero_records.extend(
+                zero_stop_rows(reports_dir, y, existing=present_by_year.get(y, set()))
+            )
+        if zero_records:
+            zdf = pd.DataFrame(zero_records).reindex(columns=combined.columns)
+            for col in RACE_COLUMNS:
+                if col in zdf.columns:
+                    zdf[col] = pd.to_numeric(zdf[col], errors="coerce")
+            combined = pd.concat([combined, zdf], ignore_index=True)
+            context.log.info(
+                "Folded in %d zero-stop filer rows across %d years (issue #41)",
+                len(zero_records), zdf["year"].nunique(),
+            )
 
     # Collapse pre-2020 'Am. Indian' race column into the 2020+ 'Native American'
     # column so downstream layers only see one. Pre-2020 reports use 'Am. Indian';

--- a/missouri_vsr/definitions/definitions.py
+++ b/missouri_vsr/definitions/definitions.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from dagster import Definitions, load_assets_from_modules
 
 from missouri_vsr.asset_checks import asset_checks
-from missouri_vsr.assets import agency_reference, audit, extract, gis, processed, program_287g, reports, state_report
+from missouri_vsr.assets import acs_population, agency_reference, audit, extract, gis, processed, program_287g, reports, state_report
 from missouri_vsr.assets.analysis import initial_impressions_2025
 from missouri_vsr.resources import LocalDirectoryResource, S3Resource
 
@@ -16,7 +16,7 @@ DATA_DIR_OUT=Path("data/out")
 # Automatically load assets from the assets modules.
 assets_loaded = load_assets_from_modules(
     [extract, reports, processed, agency_reference, audit, gis, program_287g, state_report,
-     initial_impressions_2025]
+     acs_population, initial_impressions_2025]
 )
 
 defs = Definitions(

--- a/tests/test_acs_population.py
+++ b/tests/test_acs_population.py
@@ -1,0 +1,68 @@
+"""Tests for the ACS 5-year PUMS 16+ population tabulation (acs_population_16plus)."""
+from __future__ import annotations
+
+import pandas as pd
+
+from missouri_vsr.assets.acs_population import _aggregate_16plus_by_race
+
+
+def _synthetic_pums() -> pd.DataFrame:
+    """One person per AG race category (all weight 10, age 16+), plus an under-16 row.
+
+    Covers the exact construction the AG uses, including the non-White-Hispanic
+    double-count (a Hispanic Black person lands in BOTH Black and Hispanic).
+    """
+    rows = [
+        # (AGEP, PWGTP, RAC1P, HISP)
+        (40, 10, 1, 1),   # White alone, not Hispanic  -> White
+        (40, 10, 1, 2),   # White alone, Hispanic      -> Hispanic (NOT White)
+        (40, 10, 2, 1),   # Black, not Hispanic         -> Black
+        (40, 10, 2, 3),   # Black, Hispanic             -> Black AND Hispanic (double-count)
+        (40, 10, 3, 1),   # American Indian alone       -> Native American
+        (40, 10, 4, 1),   # Alaska Native alone         -> Native American
+        (40, 10, 5, 1),   # AIAN combination            -> Native American
+        (40, 10, 6, 1),   # Asian alone                 -> Asian
+        (40, 10, 7, 1),   # NHPI alone                  -> Other
+        (40, 10, 8, 1),   # Some other race alone       -> Other
+        (40, 10, 9, 1),   # Two or more races           -> Other
+        (10, 99, 2, 1),   # under 16                    -> excluded entirely
+    ]
+    return pd.DataFrame(rows, columns=["AGEP", "PWGTP", "RAC1P", "HISP"])
+
+
+def test_category_construction_matches_ag_definition():
+    counts = _aggregate_16plus_by_race(_synthetic_pums())
+    assert counts["Total"] == 110               # 11 people x weight 10; under-16 excluded
+    assert counts["White"] == 10                # white-alone-not-Hispanic only
+    assert counts["Black"] == 20                # incl. the Hispanic Black person
+    assert counts["Hispanic"] == 20             # White-Hispanic + Black-Hispanic
+    assert counts["Native American"] == 30      # RAC1P in {3,4,5}
+    assert counts["Asian"] == 10
+    assert counts["Other"] == 30                # RAC1P in {7,8,9}
+
+
+def test_under_16_excluded():
+    """The under-16 row has weight 99; if it leaked in, Total would jump by 99."""
+    counts = _aggregate_16plus_by_race(_synthetic_pums())
+    assert counts["Total"] == 110
+
+
+def test_non_white_hispanic_double_count_identity():
+    """sum(race categories) - Total == the non-White Hispanic population (counted twice)."""
+    counts = _aggregate_16plus_by_race(_synthetic_pums())
+    races = ["White", "Black", "Hispanic", "Native American", "Asian", "Other"]
+    excess = sum(counts[r] for r in races) - counts["Total"]
+    # Only the Hispanic Black person (weight 10) is double-counted; the White-Hispanic
+    # person lands in Hispanic only (removed from White), so does NOT inflate the sum.
+    assert excess == 10
+
+
+def test_weighting_uses_pwgtp():
+    """Counts are PWGTP-weighted, not row counts."""
+    df = pd.DataFrame(
+        [(40, 25, 1, 1), (40, 75, 1, 1)],  # two White-NH people, weights 25 + 75
+        columns=["AGEP", "PWGTP", "RAC1P", "HISP"],
+    )
+    counts = _aggregate_16plus_by_race(df)
+    assert counts["White"] == 100
+    assert counts["Total"] == 100

--- a/tests/test_agencies_reporting.py
+++ b/tests/test_agencies_reporting.py
@@ -1,0 +1,74 @@
+"""Tests for the "Zero Stops" parser folded into the combine step (issue #41).
+
+`parse_zero_stop_agencies` reads the prose "Zero Stops" section out of the
+layout-extracted report text with a regex, and `zero_stop_rows` turns it into
+synthetic all-stops=0 records. Both are brittle, so we pin them against the real
+source files.
+"""
+from pathlib import Path
+
+import pytest
+
+from missouri_vsr.assets.extract import parse_zero_stop_agencies, zero_stop_rows
+
+REPORTS = Path("data/src/reports")
+
+
+def _names(year: int) -> list[str]:
+    f = REPORTS / f"VSRreport{year}.layout.txt"
+    return parse_zero_stop_agencies(f.read_text(encoding="utf-8", errors="replace"))
+
+
+def _has_layout(year: int) -> bool:
+    return (REPORTS / f"VSRreport{year}.layout.txt").exists()
+
+
+@pytest.mark.skipif(not _has_layout(2024), reason="2024 report text not present")
+def test_zero_stops_2024_known_agencies():
+    names = _names(2024)
+    # The 2024 "Zero Stops" section lists exactly 12 agencies.
+    assert len(names) == 12, names
+    joined = " | ".join(names)
+    for expected in ("Corder Police Dept", "St. Louis Community College Police Dept",
+                     "Missouri Department of Revenue"):
+        assert expected in joined, (expected, names)
+    assert not any(n.isdigit() for n in names)
+    assert not any("Agency Results" in n for n in names)
+
+
+@pytest.mark.skipif(not _has_layout(2023), reason="2023 report text not present")
+def test_zero_stops_2023_count():
+    assert len(_names(2023)) == 24
+
+
+@pytest.mark.skipif(not _has_layout(2025), reason="2025 report text not present")
+def test_zero_stops_2025_count():
+    assert len(_names(2025)) == 23
+
+
+def test_parse_empty_text_returns_empty():
+    assert parse_zero_stop_agencies("") == []
+
+
+@pytest.mark.skipif(not _has_layout(2021), reason="2021 report text not present")
+def test_zero_stops_absent_section_is_empty():
+    # 2021's report does not carry a parseable Zero Stops section.
+    assert _names(2021) == []
+
+
+@pytest.mark.skipif(not _has_layout(2024), reason="2024 report text not present")
+def test_zero_stop_rows_shape_and_dedup():
+    rows = zero_stop_rows(REPORTS, 2024)
+    assert len(rows) == 12
+    r = rows[0]
+    # Synthetic all-stops=0 row, canonical-mappable to 'stops'.
+    assert r["row_key"] == "rates-by-race--totals--all-stops"
+    assert r["Total"] == 0 and r["White"] == 0
+    assert r["year"] == 2024 and r["table_id"] == "rates-by-race"
+    # `existing` suppresses agencies already present in the tables.
+    suppressed = zero_stop_rows(REPORTS, 2024, existing={r["agency"]})
+    assert len(suppressed) == 11
+
+
+def test_zero_stop_rows_missing_year_returns_empty():
+    assert zero_stop_rows(REPORTS, 1999) == []


### PR DESCRIPTION
Lands the ACS-PUMS disparity stack on `main`. Replaces #40, which GitHub auto-closed when its base branch `analysis/disparity-10yr-window` was deleted on merge of #38 (stacked-PR base deletion closes rather than retargets).

Contents (6 commits, on top of the #38 10-yr-window base now on main):
- Self-source the disparity denominator from ACS 5-yr PUMS via the Census API (full window) + unit test + asset checks
- Fold prose "Zero Stops" filers into the dataset (issue #41)
- Outcome test for all years + bundle the searches count
- dist manifest self-labels its release version from S3_PREFIX

Tests: 63 passed, 5 skipped. The branch's data build is already published to releases/v2.2 (2026-06-16).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>